### PR TITLE
Add HW Geogessr primary app with game interface

### DIFF
--- a/react-vite-app/index.html
+++ b/react-vite-app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>react-vite-app</title>
+    <title>HW Geogessr</title>
   </head>
   <body>
     <div id="root"></div>

--- a/react-vite-app/src/App.css
+++ b/react-vite-app/src/App.css
@@ -1,42 +1,62 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+/* App Container */
+.app {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+/* Loading State */
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: linear-gradient(135deg, var(--bg-dark) 0%, var(--bg-secondary) 100%);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--border-color);
+  border-top-color: var(--accent-green);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
   to {
     transform: rotate(360deg);
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+/* Error State */
+.error-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: linear-gradient(135deg, var(--bg-dark) 0%, var(--bg-secondary) 100%);
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
 }
 
-.card {
-  padding: 2em;
+.error-message {
+  color: var(--error-red);
+  font-size: 1.2rem;
 }
 
-.read-the-docs {
-  color: #888;
+.retry-button {
+  background-color: var(--accent-green);
+  color: var(--text-primary);
+  padding: 0.8rem 2rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.retry-button:hover {
+  background-color: var(--accent-green-hover);
 }

--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -1,35 +1,66 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useGameState } from './hooks/useGameState';
+import TitleScreen from './components/TitleScreen/TitleScreen';
+import GameScreen from './components/GameScreen/GameScreen';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const {
+    screen,
+    currentImage,
+    guessLocation,
+    guessFloor,
+    isLoading,
+    error,
+    startGame,
+    placeMarker,
+    selectFloor,
+    submitGuess,
+    resetGame
+  } = useGameState();
+
+  // Error state
+  if (error) {
+    return (
+      <div className="app">
+        <div className="error-container">
+          <p className="error-message">{error}</p>
+          <button className="retry-button" onClick={resetGame}>
+            Back to Home
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="app">
+      {screen === 'title' && (
+        <TitleScreen
+          onStartGame={startGame}
+          isLoading={isLoading}
+        />
+      )}
+
+      {screen === 'game' && currentImage && (
+        <GameScreen
+          imageUrl={currentImage.url}
+          guessLocation={guessLocation}
+          guessFloor={guessFloor}
+          onMapClick={placeMarker}
+          onFloorSelect={selectFloor}
+          onSubmitGuess={submitGuess}
+          onBackToTitle={resetGame}
+        />
+      )}
+
+      {/* Loading state for game screen */}
+      {screen === 'game' && !currentImage && isLoading && (
+        <div className="loading-container">
+          <div className="loading-spinner"></div>
+        </div>
+      )}
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/react-vite-app/src/components/FloorSelector/FloorSelector.css
+++ b/react-vite-app/src/components/FloorSelector/FloorSelector.css
@@ -1,0 +1,77 @@
+.floor-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.floor-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0 0.25rem;
+}
+
+.floor-icon {
+  font-size: 1rem;
+}
+
+.floor-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.floor-button {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0.5rem;
+  background-color: var(--bg-secondary);
+  border: 2px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.floor-button:hover {
+  border-color: var(--accent-green);
+  background-color: rgba(108, 181, 45, 0.1);
+}
+
+.floor-button.selected {
+  border-color: var(--accent-green);
+  background-color: var(--accent-green);
+  color: var(--text-primary);
+}
+
+.floor-number {
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.floor-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 0.2rem;
+  opacity: 0.8;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .floor-button {
+    padding: 0.6rem 0.4rem;
+  }
+
+  .floor-number {
+    font-size: 1rem;
+  }
+
+  .floor-label {
+    font-size: 0.6rem;
+  }
+}

--- a/react-vite-app/src/components/FloorSelector/FloorSelector.jsx
+++ b/react-vite-app/src/components/FloorSelector/FloorSelector.jsx
@@ -1,0 +1,28 @@
+import './FloorSelector.css';
+
+function FloorSelector({ selectedFloor, onFloorSelect, floors = [1, 2, 3, 4] }) {
+  return (
+    <div className="floor-selector">
+      <div className="floor-header">
+        <span className="floor-icon">🏢</span>
+        <span>Select Floor</span>
+      </div>
+      <div className="floor-buttons">
+        {floors.map((floor) => (
+          <button
+            key={floor}
+            className={`floor-button ${selectedFloor === floor ? 'selected' : ''}`}
+            onClick={() => onFloorSelect(floor)}
+          >
+            <span className="floor-number">{floor}</span>
+            <span className="floor-label">
+              {floor === 1 ? '1st' : floor === 2 ? '2nd' : floor === 3 ? '3rd' : `${floor}th`}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default FloorSelector;

--- a/react-vite-app/src/components/GameScreen/GameScreen.css
+++ b/react-vite-app/src/components/GameScreen/GameScreen.css
@@ -1,0 +1,136 @@
+.game-screen {
+  display: flex;
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--bg-dark);
+}
+
+/* Image Panel - Left side */
+.image-panel {
+  flex: 7;
+  display: flex;
+  background-color: var(--bg-dark);
+  border-right: 1px solid var(--border-color);
+}
+
+/* Guess Panel - Right side */
+.guess-panel {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg-panel);
+  min-width: 320px;
+  max-width: 400px;
+}
+
+.guess-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.back-button {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.5rem 0.8rem;
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+}
+
+.back-button:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.panel-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.guess-controls {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  overflow-y: auto;
+}
+
+/* Guess Status */
+.guess-status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.status-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  transition: color 0.2s ease;
+}
+
+.status-item.complete {
+  color: var(--accent-green);
+}
+
+.status-icon {
+  font-size: 0.9rem;
+  width: 1.2rem;
+  text-align: center;
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+  .game-screen {
+    flex-direction: column;
+  }
+
+  .image-panel {
+    flex: none;
+    height: 50vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .guess-panel {
+    flex: 1;
+    min-width: 100%;
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .image-panel {
+    height: 40vh;
+  }
+
+  .guess-panel-header {
+    padding: 0.75rem 1rem;
+  }
+
+  .guess-controls {
+    padding: 1rem;
+    gap: 1rem;
+  }
+
+  .guess-status {
+    flex-direction: row;
+    justify-content: center;
+    gap: 1.5rem;
+    padding: 0.75rem 1rem;
+  }
+}

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -1,0 +1,68 @@
+import ImageViewer from '../ImageViewer/ImageViewer';
+import MapPicker from '../MapPicker/MapPicker';
+import FloorSelector from '../FloorSelector/FloorSelector';
+import GuessButton from '../GuessButton/GuessButton';
+import './GameScreen.css';
+
+function GameScreen({
+  imageUrl,
+  guessLocation,
+  guessFloor,
+  onMapClick,
+  onFloorSelect,
+  onSubmitGuess,
+  onBackToTitle
+}) {
+  const canSubmit = guessLocation !== null && guessFloor !== null;
+
+  return (
+    <div className="game-screen">
+      {/* Left panel - Image */}
+      <div className="image-panel">
+        <ImageViewer imageUrl={imageUrl} />
+      </div>
+
+      {/* Right panel - Guess controls */}
+      <div className="guess-panel">
+        <div className="guess-panel-header">
+          <button className="back-button" onClick={onBackToTitle}>
+            <span>←</span>
+            <span>Back</span>
+          </button>
+          <h2 className="panel-title">Make Your Guess</h2>
+        </div>
+
+        <div className="guess-controls">
+          <MapPicker
+            markerPosition={guessLocation}
+            onMapClick={onMapClick}
+          />
+
+          <FloorSelector
+            selectedFloor={guessFloor}
+            onFloorSelect={onFloorSelect}
+          />
+
+          <GuessButton
+            disabled={!canSubmit}
+            onClick={onSubmitGuess}
+          />
+        </div>
+
+        {/* Guess Status */}
+        <div className="guess-status">
+          <div className={`status-item ${guessLocation ? 'complete' : ''}`}>
+            <span className="status-icon">{guessLocation ? '✓' : '○'}</span>
+            <span>Location selected</span>
+          </div>
+          <div className={`status-item ${guessFloor ? 'complete' : ''}`}>
+            <span className="status-icon">{guessFloor ? '✓' : '○'}</span>
+            <span>Floor selected</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GameScreen;

--- a/react-vite-app/src/components/GuessButton/GuessButton.css
+++ b/react-vite-app/src/components/GuessButton/GuessButton.css
@@ -1,0 +1,54 @@
+.guess-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  font-weight: 600;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 16px rgba(108, 181, 45, 0.3);
+}
+
+.guess-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 24px rgba(108, 181, 45, 0.4);
+}
+
+.guess-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.guess-button.disabled,
+.guess-button:disabled {
+  background: linear-gradient(135deg, #3a3a4a 0%, #2a2a3a 100%);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.guess-icon {
+  font-size: 1.4rem;
+}
+
+.guess-text {
+  letter-spacing: 0.5px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .guess-button {
+    padding: 0.9rem;
+    font-size: 1.1rem;
+  }
+
+  .guess-icon {
+    font-size: 1.2rem;
+  }
+}

--- a/react-vite-app/src/components/GuessButton/GuessButton.jsx
+++ b/react-vite-app/src/components/GuessButton/GuessButton.jsx
@@ -1,0 +1,16 @@
+import './GuessButton.css';
+
+function GuessButton({ disabled, onClick }) {
+  return (
+    <button
+      className={`guess-button ${disabled ? 'disabled' : ''}`}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span className="guess-icon">🎯</span>
+      <span className="guess-text">Guess</span>
+    </button>
+  );
+}
+
+export default GuessButton;

--- a/react-vite-app/src/components/ImageViewer/ImageViewer.css
+++ b/react-vite-app/src/components/ImageViewer/ImageViewer.css
@@ -1,0 +1,58 @@
+.image-viewer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg-dark);
+  position: relative;
+  overflow: hidden;
+}
+
+.image-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  overflow: hidden;
+}
+
+.mystery-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.image-hint {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(12, 12, 15, 0.9);
+  backdrop-filter: blur(10px);
+  padding: 0.6rem 1.2rem;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.hint-icon {
+  font-size: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .image-container {
+    padding: 0.5rem;
+  }
+
+  .image-hint {
+    font-size: 0.8rem;
+    padding: 0.5rem 1rem;
+  }
+}

--- a/react-vite-app/src/components/ImageViewer/ImageViewer.jsx
+++ b/react-vite-app/src/components/ImageViewer/ImageViewer.jsx
@@ -1,0 +1,21 @@
+import './ImageViewer.css';
+
+function ImageViewer({ imageUrl, alt = "Mystery location" }) {
+  return (
+    <div className="image-viewer">
+      <div className="image-container">
+        <img
+          src={imageUrl}
+          alt={alt}
+          className="mystery-image"
+        />
+      </div>
+      <div className="image-hint">
+        <span className="hint-icon">📍</span>
+        <span>Where was this photo taken?</span>
+      </div>
+    </div>
+  );
+}
+
+export default ImageViewer;

--- a/react-vite-app/src/components/MapPicker/MapPicker.css
+++ b/react-vite-app/src/components/MapPicker/MapPicker.css
@@ -1,0 +1,124 @@
+.map-picker-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.map-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0 0.25rem;
+}
+
+.map-icon {
+  font-size: 1rem;
+}
+
+.map-picker {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background-color: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: crosshair;
+  border: 2px solid var(--border-color);
+  transition: border-color 0.2s ease;
+}
+
+.map-picker:hover {
+  border-color: var(--accent-green);
+}
+
+.map-svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Marker Styles */
+.marker {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.marker-pin {
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(135deg, var(--marker-color) 0%, #ff6b81 100%);
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  box-shadow: 0 4px 12px rgba(255, 71, 87, 0.5);
+  border: 2px solid white;
+  animation: dropIn 0.3s ease-out;
+}
+
+.marker-pin::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.marker-pulse {
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 12px;
+  height: 4px;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 50%;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes dropIn {
+  0% {
+    opacity: 0;
+    transform: rotate(-45deg) scale(0.5) translateY(-20px);
+  }
+  50% {
+    transform: rotate(-45deg) scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: rotate(-45deg) scale(1);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: translateX(-50%) scale(1);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translateX(-50%) scale(1.5);
+    opacity: 0.1;
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .map-picker {
+    border-radius: 8px;
+  }
+
+  .marker-pin {
+    width: 20px;
+    height: 20px;
+  }
+
+  .marker-pin::after {
+    width: 6px;
+    height: 6px;
+  }
+}

--- a/react-vite-app/src/components/MapPicker/MapPicker.jsx
+++ b/react-vite-app/src/components/MapPicker/MapPicker.jsx
@@ -1,0 +1,101 @@
+import { useRef } from 'react';
+import './MapPicker.css';
+
+function MapPicker({ markerPosition, onMapClick }) {
+  const mapRef = useRef(null);
+
+  const handleClick = (event) => {
+    if (!mapRef.current) return;
+
+    const rect = mapRef.current.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 100;
+    const y = ((event.clientY - rect.top) / rect.height) * 100;
+
+    // Clamp values between 0 and 100
+    const clampedX = Math.max(0, Math.min(100, x));
+    const clampedY = Math.max(0, Math.min(100, y));
+
+    onMapClick({ x: clampedX, y: clampedY });
+  };
+
+  return (
+    <div className="map-picker-container">
+      <div className="map-header">
+        <span className="map-icon">🗺️</span>
+        <span>Click to place your guess</span>
+      </div>
+      <div
+        className="map-picker"
+        ref={mapRef}
+        onClick={handleClick}
+      >
+        {/* Placeholder map SVG */}
+        <svg
+          className="map-svg"
+          viewBox="0 0 400 300"
+          preserveAspectRatio="xMidYMid meet"
+        >
+          {/* Background */}
+          <rect x="0" y="0" width="400" height="300" fill="#1a1a2e" />
+
+          {/* Grid lines */}
+          <g stroke="#2a2a4a" strokeWidth="0.5">
+            {[...Array(9)].map((_, i) => (
+              <line key={`v${i}`} x1={(i + 1) * 40} y1="0" x2={(i + 1) * 40} y2="300" />
+            ))}
+            {[...Array(7)].map((_, i) => (
+              <line key={`h${i}`} x1="0" y1={(i + 1) * 40} x2="400" y2={(i + 1) * 40} />
+            ))}
+          </g>
+
+          {/* Buildings - Sample campus layout */}
+          <g fill="#16213e" stroke="#3a3a5a" strokeWidth="1">
+            {/* Main Building */}
+            <rect x="50" y="80" width="120" height="80" rx="4" />
+            <text x="110" y="125" fill="#6b6b6b" fontSize="10" textAnchor="middle">Main</text>
+
+            {/* Library */}
+            <rect x="200" y="60" width="80" height="60" rx="4" />
+            <text x="240" y="95" fill="#6b6b6b" fontSize="10" textAnchor="middle">Library</text>
+
+            {/* Gym */}
+            <rect x="300" y="100" width="70" height="100" rx="4" />
+            <text x="335" y="155" fill="#6b6b6b" fontSize="10" textAnchor="middle">Gym</text>
+
+            {/* Science Building */}
+            <rect x="100" y="190" width="100" height="70" rx="4" />
+            <text x="150" y="230" fill="#6b6b6b" fontSize="10" textAnchor="middle">Science</text>
+
+            {/* Arts Center */}
+            <rect x="230" y="180" width="90" height="80" rx="4" />
+            <text x="275" y="225" fill="#6b6b6b" fontSize="10" textAnchor="middle">Arts</text>
+          </g>
+
+          {/* Paths */}
+          <g stroke="#3a3a5a" strokeWidth="2" fill="none" strokeDasharray="4,4">
+            <path d="M170 120 L200 90" />
+            <path d="M170 130 L200 200 L230 220" />
+            <path d="M280 90 L300 150" />
+            <path d="M200 230 L230 220" />
+          </g>
+        </svg>
+
+        {/* Marker */}
+        {markerPosition && (
+          <div
+            className="marker"
+            style={{
+              left: `${markerPosition.x}%`,
+              top: `${markerPosition.y}%`
+            }}
+          >
+            <div className="marker-pin"></div>
+            <div className="marker-pulse"></div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MapPicker;

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.css
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.css
@@ -1,0 +1,176 @@
+.title-screen {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.title-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.title-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 20% 80%, rgba(108, 181, 45, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(108, 181, 45, 0.08) 0%, transparent 40%);
+}
+
+.title-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(0deg, rgba(12, 12, 15, 0.8) 0%, transparent 50%),
+    linear-gradient(180deg, rgba(12, 12, 15, 0.4) 0%, transparent 30%);
+}
+
+.title-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem;
+  max-width: 600px;
+}
+
+.logo-container {
+  margin-bottom: 1.5rem;
+  animation: float 3s ease-in-out infinite;
+}
+
+.logo-icon {
+  font-size: 5rem;
+  display: block;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+.game-title {
+  font-size: 4rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-shadow: 0 0 40px rgba(108, 181, 45, 0.3);
+  margin-bottom: 1rem;
+  letter-spacing: -1px;
+}
+
+.tagline {
+  font-size: 1.4rem;
+  color: var(--text-secondary);
+  margin-bottom: 2.5rem;
+  font-weight: 400;
+}
+
+.start-button {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  font-size: 1.3rem;
+  font-weight: 600;
+  padding: 1rem 3rem;
+  border-radius: 50px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.start-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.start-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.start-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.button-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.subtitle {
+  margin-top: 2rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .game-title {
+    font-size: 2.8rem;
+  }
+
+  .tagline {
+    font-size: 1.1rem;
+  }
+
+  .logo-icon {
+    font-size: 4rem;
+  }
+
+  .start-button {
+    font-size: 1.1rem;
+    padding: 0.9rem 2.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .game-title {
+    font-size: 2.2rem;
+  }
+
+  .tagline {
+    font-size: 1rem;
+  }
+
+  .logo-icon {
+    font-size: 3rem;
+  }
+}

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -1,0 +1,37 @@
+import './TitleScreen.css';
+
+function TitleScreen({ onStartGame, isLoading }) {
+  return (
+    <div className="title-screen">
+      <div className="title-background">
+        <div className="title-overlay"></div>
+      </div>
+      <div className="title-content">
+        <div className="logo-container">
+          <span className="logo-icon">🌍</span>
+        </div>
+        <h1 className="game-title">HW Geogessr</h1>
+        <p className="tagline">Can you guess the location on campus?</p>
+        <button
+          className="start-button"
+          onClick={onStartGame}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <>
+              <span className="button-spinner"></span>
+              Loading...
+            </>
+          ) : (
+            'Start Game'
+          )}
+        </button>
+        <p className="subtitle">
+          Explore Harvard-Westlake through photos
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default TitleScreen;

--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -1,0 +1,117 @@
+import { useState, useCallback } from 'react';
+import { getRandomImage } from '../services/imageService';
+
+/**
+ * Custom hook for managing game state
+ * Handles screen transitions, image loading, and guess tracking
+ */
+export function useGameState() {
+  // Current screen: 'title' or 'game'
+  const [screen, setScreen] = useState('title');
+
+  // Current image being shown
+  const [currentImage, setCurrentImage] = useState(null);
+
+  // User's guess location on the map (x, y in percentages)
+  const [guessLocation, setGuessLocation] = useState(null);
+
+  // User's guess for the floor
+  const [guessFloor, setGuessFloor] = useState(null);
+
+  // Loading state
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Error state
+  const [error, setError] = useState(null);
+
+  /**
+   * Start a new game - fetch a random image and show game screen
+   */
+  const startGame = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const image = await getRandomImage();
+      setCurrentImage(image);
+      setGuessLocation(null);
+      setGuessFloor(null);
+      setScreen('game');
+    } catch (err) {
+      console.error('Failed to start game:', err);
+      setError('Failed to load image. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  /**
+   * Place a marker on the map
+   */
+  const placeMarker = useCallback((coords) => {
+    setGuessLocation(coords);
+  }, []);
+
+  /**
+   * Select a floor
+   */
+  const selectFloor = useCallback((floor) => {
+    setGuessFloor(floor);
+  }, []);
+
+  /**
+   * Submit the guess
+   */
+  const submitGuess = useCallback(() => {
+    if (!guessLocation || !guessFloor) {
+      console.warn('Cannot submit: missing location or floor');
+      return;
+    }
+
+    // Log the guess for now (scoring will be implemented later)
+    console.log('Guess submitted:', {
+      location: guessLocation,
+      floor: guessFloor,
+      image: currentImage
+    });
+
+    // Show an alert with the guess (placeholder for result screen)
+    alert(
+      `Guess submitted!\n\n` +
+      `Location: (${guessLocation.x.toFixed(1)}%, ${guessLocation.y.toFixed(1)}%)\n` +
+      `Floor: ${guessFloor}\n\n` +
+      `(Result screen coming soon!)`
+    );
+
+    // For now, go back to title screen after guess
+    resetGame();
+  }, [guessLocation, guessFloor, currentImage]);
+
+  /**
+   * Reset game and return to title screen
+   */
+  const resetGame = useCallback(() => {
+    setScreen('title');
+    setCurrentImage(null);
+    setGuessLocation(null);
+    setGuessFloor(null);
+    setError(null);
+  }, []);
+
+  return {
+    // State
+    screen,
+    currentImage,
+    guessLocation,
+    guessFloor,
+    isLoading,
+    error,
+
+    // Actions
+    startGame,
+    placeMarker,
+    selectFloor,
+    submitGuess,
+    resetGame
+  };
+}

--- a/react-vite-app/src/index.css
+++ b/react-vite-app/src/index.css
@@ -1,68 +1,100 @@
+/* GeoGuessr-inspired Dark Theme */
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  /* Color Palette */
+  --bg-dark: #0c0c0f;
+  --bg-secondary: #1a1a2e;
+  --bg-card: #16213e;
+  --bg-panel: #0f0f23;
+  --accent-green: #6cb52d;
+  --accent-green-hover: #5aa020;
+  --accent-green-light: #7dd33a;
+  --text-primary: #ffffff;
+  --text-secondary: #a0a0a0;
+  --text-muted: #6b6b6b;
+  --border-color: #2a2a4a;
+  --border-light: #3a3a5a;
+  --error-red: #e74c3c;
+  --marker-color: #ff4757;
+
+  /* Typography */
+  font-family: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  /* Rendering */
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+* {
+  box-sizing: border-box;
 }
-a:hover {
-  color: #535bf2;
+
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--bg-dark);
+  color: var(--text-primary);
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+/* Global Typography */
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
+p {
+  margin: 0;
+}
+
+/* Global Button Reset */
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  border: none;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: all 0.2s ease;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Link Reset */
+a {
+  color: var(--accent-green);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-green-light);
+}
+
+/* Image Reset */
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* Selection */
+::selection {
+  background-color: var(--accent-green);
+  color: var(--text-primary);
 }

--- a/react-vite-app/src/services/imageService.js
+++ b/react-vite-app/src/services/imageService.js
@@ -1,0 +1,84 @@
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+// Sample images for development (used when Firestore has no data)
+const SAMPLE_IMAGES = [
+  {
+    id: 'sample-1',
+    url: 'https://images.unsplash.com/photo-1562774053-701939374585?w=800&q=80',
+    correctLocation: { x: 35, y: 45 },
+    correctFloor: 2,
+    description: 'Main hallway near the library'
+  },
+  {
+    id: 'sample-2',
+    url: 'https://images.unsplash.com/photo-1541829070764-84a7d30dd3f3?w=800&q=80',
+    correctLocation: { x: 65, y: 30 },
+    correctFloor: 1,
+    description: 'Science building entrance'
+  },
+  {
+    id: 'sample-3',
+    url: 'https://images.unsplash.com/photo-1580582932707-520aed937b7b?w=800&q=80',
+    correctLocation: { x: 80, y: 60 },
+    correctFloor: 1,
+    description: 'Gymnasium interior'
+  },
+  {
+    id: 'sample-4',
+    url: 'https://images.unsplash.com/photo-1497633762265-9d179a990aa6?w=800&q=80',
+    correctLocation: { x: 25, y: 75 },
+    correctFloor: 3,
+    description: 'Arts center studio'
+  },
+  {
+    id: 'sample-5',
+    url: 'https://images.unsplash.com/photo-1519452635265-7b1fbfd1e4e0?w=800&q=80',
+    correctLocation: { x: 50, y: 50 },
+    correctFloor: 2,
+    description: 'Outdoor courtyard view'
+  }
+];
+
+/**
+ * Fetches a random image from Firestore
+ * Falls back to sample images if Firestore is empty or unavailable
+ */
+export async function getRandomImage() {
+  try {
+    const imagesRef = collection(db, 'images');
+    const snapshot = await getDocs(imagesRef);
+
+    if (snapshot.empty) {
+      console.log('No images in Firestore, using sample images');
+      return getRandomSampleImage();
+    }
+
+    const images = snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data()
+    }));
+
+    const randomIndex = Math.floor(Math.random() * images.length);
+    return images[randomIndex];
+  } catch (error) {
+    console.error('Error fetching from Firestore:', error);
+    console.log('Falling back to sample images');
+    return getRandomSampleImage();
+  }
+}
+
+/**
+ * Returns a random sample image for development
+ */
+export function getRandomSampleImage() {
+  const randomIndex = Math.floor(Math.random() * SAMPLE_IMAGES.length);
+  return SAMPLE_IMAGES[randomIndex];
+}
+
+/**
+ * Get all sample images (useful for testing)
+ */
+export function getAllSampleImages() {
+  return [...SAMPLE_IMAGES];
+}


### PR DESCRIPTION
## Summary
- Implements the primary HW Geogessr game application with GeoGuessr-style UI/UX
- Creates title screen with "HW Geogessr" branding and animated Start button
- Adds game screen with split layout: 70% image viewer, 30% guess panel
- Implements interactive MapPicker with click-to-place markers (percentage-based coordinates)
- Adds FloorSelector component for floor/level guessing (floors 1-4)
- Creates ImageViewer for full-screen mystery location display
- Implements imageService with Firestore integration and fallback sample images
- Adds useGameState hook for centralized game state management
- Applies GeoGuessr-inspired dark theme with green accent colors

## New Components
| Component | Purpose |
|-----------|---------|
| `TitleScreen` | Hero landing page with title and start button |
| `GameScreen` | Main game layout orchestrating all gameplay elements |
| `ImageViewer` | Displays the mystery location image |
| `MapPicker` | Interactive map for placing guess markers |
| `FloorSelector` | UI for selecting floor guess |
| `GuessButton` | Submit button (disabled until ready) |

## Test plan
- [ ] Run `npm run dev` and verify title screen displays "HW Geogessr"
- [ ] Click Start button and verify game screen loads with sample image
- [ ] Click on the map and verify marker appears at clicked location
- [ ] Select a floor and verify button shows selected state
- [ ] Verify Guess button enables only when both location and floor are selected
- [ ] Click Guess and verify alert shows the coordinates
- [ ] Test responsive design on mobile viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)