### PR TITLE
Add GeoGuessr-style results screens

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -1,20 +1,28 @@
 import { useGameState } from './hooks/useGameState';
 import TitleScreen from './components/TitleScreen/TitleScreen';
 import GameScreen from './components/GameScreen/GameScreen';
+import ResultScreen from './components/ResultScreen/ResultScreen';
+import FinalResultsScreen from './components/FinalResultsScreen/FinalResultsScreen';
 import './App.css';
 
 function App() {
   const {
     screen,
+    currentRound,
+    totalRounds,
     currentImage,
     guessLocation,
     guessFloor,
+    currentResult,
+    roundResults,
     isLoading,
     error,
     startGame,
     placeMarker,
     selectFloor,
     submitGuess,
+    nextRound,
+    viewFinalResults,
     resetGame
   } = useGameState();
 
@@ -49,6 +57,31 @@ function App() {
           onMapClick={placeMarker}
           onFloorSelect={selectFloor}
           onSubmitGuess={submitGuess}
+          onBackToTitle={resetGame}
+          currentRound={currentRound}
+          totalRounds={totalRounds}
+        />
+      )}
+
+      {screen === 'result' && currentResult && (
+        <ResultScreen
+          guessLocation={currentResult.guessLocation}
+          guessFloor={currentResult.guessFloor}
+          actualLocation={currentResult.actualLocation}
+          actualFloor={currentResult.actualFloor}
+          imageUrl={currentResult.imageUrl}
+          roundNumber={currentRound}
+          totalRounds={totalRounds}
+          onNextRound={nextRound}
+          onViewFinalResults={viewFinalResults}
+          isLastRound={currentRound >= totalRounds}
+        />
+      )}
+
+      {screen === 'finalResults' && (
+        <FinalResultsScreen
+          rounds={roundResults}
+          onPlayAgain={startGame}
           onBackToTitle={resetGame}
         />
       )}

--- a/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.css
+++ b/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.css
@@ -1,0 +1,408 @@
+.final-results-screen {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.final-results-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.final-results-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 30% 20%, rgba(108, 181, 45, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 70% 80%, rgba(108, 181, 45, 0.1) 0%, transparent 40%);
+}
+
+/* Confetti */
+.confetti-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.confetti {
+  position: absolute;
+  top: -20px;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  animation: confettiFall 4s ease-in-out infinite;
+}
+
+@keyframes confettiFall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(100vh) rotate(720deg);
+    opacity: 0;
+  }
+}
+
+/* Content */
+.final-results-content {
+  position: relative;
+  z-index: 1;
+  max-width: 700px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Hero Section */
+.results-hero {
+  text-align: center;
+  padding-top: 1rem;
+}
+
+.performance-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  margin-bottom: 1.5rem;
+  animation: badgePop 0.6s ease-out;
+}
+
+.performance-badge.perfect {
+  background: linear-gradient(135deg, #ffd700 0%, #ffaa00 100%);
+  box-shadow: 0 0 40px rgba(255, 215, 0, 0.6);
+}
+
+.performance-badge.excellent {
+  background: linear-gradient(135deg, var(--accent-green) 0%, #4a9c20 100%);
+  box-shadow: 0 0 40px rgba(108, 181, 45, 0.5);
+}
+
+.performance-badge.great {
+  background: linear-gradient(135deg, #3498db 0%, #2980b9 100%);
+  box-shadow: 0 0 40px rgba(52, 152, 219, 0.5);
+}
+
+.performance-badge.good {
+  background: linear-gradient(135deg, #9b59b6 0%, #8e44ad 100%);
+  box-shadow: 0 0 40px rgba(155, 89, 182, 0.5);
+}
+
+.performance-badge.okay {
+  background: linear-gradient(135deg, #e67e22 0%, #d35400 100%);
+  box-shadow: 0 0 40px rgba(230, 126, 34, 0.5);
+}
+
+.performance-badge.beginner {
+  background: linear-gradient(135deg, #95a5a6 0%, #7f8c8d 100%);
+  box-shadow: 0 0 40px rgba(149, 165, 166, 0.5);
+}
+
+@keyframes badgePop {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.performance-emoji {
+  font-size: 3rem;
+}
+
+.results-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.performance-text {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.performance-text.perfect { color: #ffd700; }
+.performance-text.excellent { color: var(--accent-green); }
+.performance-text.great { color: #3498db; }
+.performance-text.good { color: #9b59b6; }
+.performance-text.okay { color: #e67e22; }
+.performance-text.beginner { color: #95a5a6; }
+
+/* Total Score */
+.total-score-container {
+  display: flex;
+  justify-content: center;
+}
+
+.total-score-box {
+  background: linear-gradient(135deg, var(--bg-card) 0%, var(--bg-secondary) 100%);
+  border: 2px solid var(--accent-green);
+  border-radius: 20px;
+  padding: 2rem 3rem;
+  text-align: center;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3), 0 0 30px rgba(108, 181, 45, 0.2);
+}
+
+.total-label {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: 0.5rem;
+}
+
+.total-value {
+  display: block;
+  font-size: 4rem;
+  font-weight: 800;
+  color: var(--accent-green);
+  text-shadow: 0 0 30px rgba(108, 181, 45, 0.5);
+  line-height: 1.1;
+}
+
+.total-max {
+  display: block;
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin-top: 0.5rem;
+}
+
+/* Rounds Breakdown */
+.rounds-breakdown {
+  background-color: var(--bg-card);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.breakdown-title {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+  font-weight: 500;
+}
+
+.rounds-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.round-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background-color: var(--bg-secondary);
+  border-radius: 12px;
+  transition: transform 0.2s ease;
+}
+
+.round-item:hover {
+  transform: translateX(4px);
+}
+
+.round-number {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 60px;
+  font-weight: 500;
+}
+
+.round-details {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.round-image {
+  width: 60px;
+  height: 40px;
+  border-radius: 6px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.round-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.round-stats {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.round-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.round-stat-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.round-stat-value {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.round-stat-value.correct {
+  color: var(--accent-green);
+}
+
+.round-stat-value.penalty {
+  color: var(--error-red);
+}
+
+.round-score {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  min-width: 80px;
+  justify-content: flex-end;
+}
+
+.round-score-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.round-score-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Action Buttons */
+.final-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  padding-bottom: 1rem;
+}
+
+.play-again-button,
+.home-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.play-again-button {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  border: none;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+}
+
+.play-again-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.home-button {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 2px solid var(--border-color);
+}
+
+.home-button:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.button-icon {
+  font-size: 1.2rem;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .final-results-screen {
+    padding: 1rem;
+  }
+
+  .results-title {
+    font-size: 2rem;
+  }
+
+  .performance-badge {
+    width: 80px;
+    height: 80px;
+  }
+
+  .performance-emoji {
+    font-size: 2.5rem;
+  }
+
+  .total-score-box {
+    padding: 1.5rem 2rem;
+  }
+
+  .total-value {
+    font-size: 3rem;
+  }
+
+  .round-details {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .round-stats {
+    gap: 1rem;
+  }
+
+  .final-actions {
+    flex-direction: column;
+  }
+
+  .play-again-button,
+  .home-button {
+    width: 100%;
+  }
+}

--- a/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
+++ b/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useMemo } from 'react';
+import './FinalResultsScreen.css';
+
+/**
+ * Calculate performance rating based on total score
+ */
+function getPerformanceRating(totalScore, maxPossible) {
+  const percentage = (totalScore / maxPossible) * 100;
+  if (percentage >= 95) return { rating: 'Perfect!', emoji: '🏆', class: 'perfect' };
+  if (percentage >= 80) return { rating: 'Excellent!', emoji: '🌟', class: 'excellent' };
+  if (percentage >= 60) return { rating: 'Great!', emoji: '👏', class: 'great' };
+  if (percentage >= 40) return { rating: 'Good', emoji: '👍', class: 'good' };
+  if (percentage >= 20) return { rating: 'Keep Practicing', emoji: '📍', class: 'okay' };
+  return { rating: 'Beginner', emoji: '🎯', class: 'beginner' };
+}
+
+const CONFETTI_COLORS = ['#6cb52d', '#ffc107', '#ff4757', '#3498db', '#9b59b6'];
+
+/**
+ * Generate confetti data once (outside render to avoid impure calls during render)
+ */
+function generateConfettiData(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    left: `${Math.random() * 100}%`,
+    delay: `${Math.random() * 2}s`,
+    color: CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)]
+  }));
+}
+
+function FinalResultsScreen({ rounds, onPlayAgain, onBackToTitle }) {
+  const [animationComplete, setAnimationComplete] = useState(false);
+  const [displayedTotal, setDisplayedTotal] = useState(0);
+
+  const totalScore = rounds.reduce((sum, round) => sum + round.score, 0);
+  const maxPossible = rounds.length * 5000;
+  const performance = getPerformanceRating(totalScore, maxPossible);
+
+  // Generate confetti data once and memoize it
+  const confettiPieces = useMemo(() => generateConfettiData(30), []);
+
+  // Animate total score
+  useEffect(() => {
+    const duration = 1500;
+    const steps = 50;
+    const increment = totalScore / steps;
+    let current = 0;
+
+    const interval = setInterval(() => {
+      current += increment;
+      if (current >= totalScore) {
+        setDisplayedTotal(totalScore);
+        clearInterval(interval);
+        setTimeout(() => setAnimationComplete(true), 300);
+      } else {
+        setDisplayedTotal(Math.round(current));
+      }
+    }, duration / steps);
+
+    return () => clearInterval(interval);
+  }, [totalScore]);
+
+  return (
+    <div className="final-results-screen">
+      <div className="final-results-background">
+        <div className="confetti-container">
+          {animationComplete && performance.class !== 'beginner' && performance.class !== 'okay' && (
+            <>
+              {confettiPieces.map((piece) => (
+                <div
+                  key={piece.id}
+                  className="confetti"
+                  style={{
+                    left: piece.left,
+                    animationDelay: piece.delay,
+                    backgroundColor: piece.color
+                  }}
+                />
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="final-results-content">
+        {/* Header with performance */}
+        <div className="results-hero">
+          <div className={`performance-badge ${performance.class}`}>
+            <span className="performance-emoji">{performance.emoji}</span>
+          </div>
+          <h1 className="results-title">Game Complete!</h1>
+          <p className={`performance-text ${performance.class}`}>{performance.rating}</p>
+        </div>
+
+        {/* Total Score Display */}
+        <div className="total-score-container">
+          <div className="total-score-box">
+            <span className="total-label">Total Score</span>
+            <span className="total-value">{displayedTotal.toLocaleString()}</span>
+            <span className="total-max">/ {maxPossible.toLocaleString()} points</span>
+          </div>
+        </div>
+
+        {/* Round by Round Breakdown */}
+        <div className="rounds-breakdown">
+          <h2 className="breakdown-title">Round Breakdown</h2>
+          <div className="rounds-list">
+            {rounds.map((round, index) => (
+              <div key={index} className="round-item">
+                <div className="round-number">Round {index + 1}</div>
+                <div className="round-details">
+                  <div className="round-image">
+                    <img src={round.imageUrl} alt={`Round ${index + 1}`} />
+                  </div>
+                  <div className="round-stats">
+                    <div className="round-stat">
+                      <span className="round-stat-label">Location</span>
+                      <span className="round-stat-value">{round.locationScore.toLocaleString()}</span>
+                    </div>
+                    <div className="round-stat">
+                      <span className="round-stat-label">Floor</span>
+                      <span className={`round-stat-value ${round.floorCorrect ? 'correct' : 'penalty'}`}>
+                        {round.floorCorrect ? '✓' : '-20%'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="round-score">
+                  <span className="round-score-value">{round.score.toLocaleString()}</span>
+                  <span className="round-score-label">pts</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="final-actions">
+          <button className="play-again-button" onClick={onPlayAgain}>
+            <span className="button-icon">🔄</span>
+            Play Again
+          </button>
+          <button className="home-button" onClick={onBackToTitle}>
+            <span className="button-icon">🏠</span>
+            Back to Home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FinalResultsScreen;

--- a/react-vite-app/src/components/GameScreen/GameScreen.css
+++ b/react-vite-app/src/components/GameScreen/GameScreen.css
@@ -53,6 +53,20 @@
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary);
+  flex: 1;
+}
+
+.round-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.8rem;
+  background-color: var(--bg-card);
+  border: 1px solid var(--accent-green);
+  border-radius: 20px;
+  color: var(--accent-green);
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .guess-controls {

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -11,7 +11,9 @@ function GameScreen({
   onMapClick,
   onFloorSelect,
   onSubmitGuess,
-  onBackToTitle
+  onBackToTitle,
+  currentRound = 1,
+  totalRounds = 5
 }) {
   const canSubmit = guessLocation !== null && guessFloor !== null;
 
@@ -30,6 +32,9 @@ function GameScreen({
             <span>Back</span>
           </button>
           <h2 className="panel-title">Make Your Guess</h2>
+          <div className="round-badge">
+            {currentRound} / {totalRounds}
+          </div>
         </div>
 
         <div className="guess-controls">

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.css
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.css
@@ -1,0 +1,376 @@
+.result-screen {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 100%);
+  padding: 1.5rem;
+}
+
+/* Header */
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.round-indicator {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.score-display {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: all 0.5s ease-out;
+}
+
+.score-display.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.score-label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.score-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  text-shadow: 0 0 20px rgba(108, 181, 45, 0.5);
+}
+
+.score-max {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+/* Main Content */
+.result-content {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 1.5rem;
+  min-height: 0;
+}
+
+/* Map Container */
+.result-map-container {
+  background-color: var(--bg-card);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+}
+
+.result-map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  background-color: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.result-map .map-svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Result Line Animation */
+.result-line {
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: drawLine 0.8s ease-out forwards;
+}
+
+@keyframes drawLine {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* Markers */
+.result-marker {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.marker-pin {
+  width: 28px;
+  height: 28px;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 3px solid white;
+  animation: markerDrop 0.5s ease-out;
+}
+
+.guess-pin {
+  background: linear-gradient(135deg, #ff4757 0%, #ff6b81 100%);
+  box-shadow: 0 4px 12px rgba(255, 71, 87, 0.5);
+}
+
+.actual-pin {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-light) 100%);
+  box-shadow: 0 4px 12px rgba(108, 181, 45, 0.5);
+}
+
+.marker-pin::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 10px;
+  height: 10px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.marker-label {
+  margin-top: 8px;
+  padding: 4px 10px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: white;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+@keyframes markerDrop {
+  0% {
+    opacity: 0;
+    transform: rotate(-45deg) scale(0.5) translateY(-30px);
+  }
+  60% {
+    transform: rotate(-45deg) scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: rotate(-45deg) scale(1);
+  }
+}
+
+/* Details Panel */
+.result-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.result-image-preview {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  aspect-ratio: 16 / 9;
+}
+
+.result-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.result-stats {
+  background-color: var(--bg-card);
+  border-radius: 12px;
+  padding: 1.25rem;
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stat-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.stat-icon {
+  font-size: 1.25rem;
+  width: 32px;
+  text-align: center;
+}
+
+.stat-label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  min-width: 70px;
+}
+
+.stat-value {
+  margin-left: auto;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.stat-value.correct {
+  color: var(--accent-green);
+}
+
+.stat-value.incorrect {
+  color: var(--error-red);
+}
+
+/* Score Breakdown */
+.score-breakdown {
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.breakdown-row.bonus {
+  color: var(--accent-green);
+}
+
+.breakdown-row.penalty {
+  color: var(--error-red);
+}
+
+.breakdown-row.total {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--border-color);
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+}
+
+/* Next Round Button */
+.next-round-button {
+  margin-top: auto;
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.next-round-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.next-round-button:active {
+  transform: translateY(0);
+}
+
+.button-arrow {
+  font-size: 1.3rem;
+  transition: transform 0.2s ease;
+}
+
+.next-round-button:hover .button-arrow {
+  transform: translateX(4px);
+}
+
+/* Progress Dots */
+.round-progress {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1.5rem 0 0.5rem;
+}
+
+.progress-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: var(--bg-card);
+  border: 2px solid var(--border-color);
+  transition: all 0.3s ease;
+}
+
+.progress-dot.completed {
+  background-color: var(--accent-green);
+  border-color: var(--accent-green);
+}
+
+.progress-dot.current {
+  border-color: var(--accent-green);
+  box-shadow: 0 0 10px rgba(108, 181, 45, 0.5);
+}
+
+/* Responsive Design */
+@media (max-width: 900px) {
+  .result-content {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+
+  .result-map {
+    min-height: 300px;
+  }
+
+  .score-value {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .result-screen {
+    padding: 1rem;
+  }
+
+  .result-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .score-display {
+    align-self: flex-end;
+  }
+
+  .result-map {
+    min-height: 250px;
+  }
+
+  .marker-pin {
+    width: 22px;
+    height: 22px;
+  }
+
+  .marker-label {
+    font-size: 0.65rem;
+    padding: 3px 6px;
+  }
+
+  .next-round-button {
+    padding: 0.9rem 1.5rem;
+    font-size: 1rem;
+  }
+}

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -1,0 +1,272 @@
+import { useRef, useEffect, useState } from 'react';
+import './ResultScreen.css';
+
+/**
+ * Calculate distance between two points (in percentage coordinates)
+ * Returns distance as a percentage of the map diagonal
+ */
+function calculateDistance(guess, actual) {
+  const dx = guess.x - actual.x;
+  const dy = guess.y - actual.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Calculate score based on distance (0-5000 points per round, GeoGuessr style)
+ * Perfect guess = 5000 points
+ * Score decreases exponentially with distance
+ */
+function calculateScore(distance) {
+  // Max distance on a 100x100 grid is ~141 (diagonal)
+  // Use exponential decay for scoring
+  const maxScore = 5000;
+  const decayRate = 0.05; // Adjust for difficulty
+  const score = Math.round(maxScore * Math.exp(-decayRate * distance));
+  return Math.max(0, Math.min(maxScore, score));
+}
+
+/**
+ * Format distance as a readable string
+ */
+function formatDistance(distance) {
+  // Convert percentage distance to approximate "units" for display
+  // In a real campus, this might be meters or feet
+  const units = Math.round(distance * 2); // Arbitrary scaling
+  if (units < 5) return 'Perfect!';
+  if (units < 20) return `${units} ft away`;
+  return `${units} ft away`;
+}
+
+function ResultScreen({
+  guessLocation,
+  guessFloor,
+  actualLocation,
+  actualFloor,
+  imageUrl,
+  roundNumber,
+  totalRounds,
+  onNextRound,
+  onViewFinalResults,
+  isLastRound
+}) {
+  const mapRef = useRef(null);
+  const [animationPhase, setAnimationPhase] = useState(0);
+  const [displayedScore, setDisplayedScore] = useState(0);
+
+  const distance = calculateDistance(guessLocation, actualLocation);
+  const locationScore = calculateScore(distance);
+  const floorCorrect = guessFloor === actualFloor;
+  // Multiply by 0.8 for incorrect floor
+  const totalScore = floorCorrect ? locationScore : Math.round(locationScore * 0.8);
+  const floorPenalty = floorCorrect ? 0 : Math.round(locationScore * 0.2);
+
+  // Animation sequence
+  useEffect(() => {
+    // Phase 0: Initial state
+    // Phase 1: Show actual location marker
+    // Phase 2: Draw line between markers
+    // Phase 3: Show score
+    const timers = [
+      setTimeout(() => setAnimationPhase(1), 300),
+      setTimeout(() => setAnimationPhase(2), 800),
+      setTimeout(() => setAnimationPhase(3), 1300),
+    ];
+
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  // Animate score counter
+  useEffect(() => {
+    if (animationPhase >= 3) {
+      const duration = 1000;
+      const steps = 30;
+      const increment = totalScore / steps;
+      let current = 0;
+
+      const interval = setInterval(() => {
+        current += increment;
+        if (current >= totalScore) {
+          setDisplayedScore(totalScore);
+          clearInterval(interval);
+        } else {
+          setDisplayedScore(Math.round(current));
+        }
+      }, duration / steps);
+
+      return () => clearInterval(interval);
+    }
+  }, [animationPhase, totalScore]);
+
+  return (
+    <div className="result-screen">
+      {/* Top section - Round info and score */}
+      <div className="result-header">
+        <div className="round-indicator">
+          Round {roundNumber} of {totalRounds}
+        </div>
+        <div className={`score-display ${animationPhase >= 3 ? 'visible' : ''}`}>
+          <span className="score-label">Score</span>
+          <span className="score-value">{displayedScore.toLocaleString()}</span>
+          <span className="score-max">/ 5,000</span>
+        </div>
+      </div>
+
+      {/* Main content - Map with results */}
+      <div className="result-content">
+        <div className="result-map-container">
+          <div className="result-map" ref={mapRef}>
+            {/* Map SVG - same as MapPicker */}
+            <svg
+              className="map-svg"
+              viewBox="0 0 400 300"
+              preserveAspectRatio="xMidYMid meet"
+            >
+              {/* Background */}
+              <rect x="0" y="0" width="400" height="300" fill="#1a1a2e" />
+
+              {/* Grid lines */}
+              <g stroke="#2a2a4a" strokeWidth="0.5">
+                {[...Array(9)].map((_, i) => (
+                  <line key={`v${i}`} x1={(i + 1) * 40} y1="0" x2={(i + 1) * 40} y2="300" />
+                ))}
+                {[...Array(7)].map((_, i) => (
+                  <line key={`h${i}`} x1="0" y1={(i + 1) * 40} x2="400" y2={(i + 1) * 40} />
+                ))}
+              </g>
+
+              {/* Buildings */}
+              <g fill="#16213e" stroke="#3a3a5a" strokeWidth="1">
+                <rect x="50" y="80" width="120" height="80" rx="4" />
+                <text x="110" y="125" fill="#6b6b6b" fontSize="10" textAnchor="middle">Main</text>
+
+                <rect x="200" y="60" width="80" height="60" rx="4" />
+                <text x="240" y="95" fill="#6b6b6b" fontSize="10" textAnchor="middle">Library</text>
+
+                <rect x="300" y="100" width="70" height="100" rx="4" />
+                <text x="335" y="155" fill="#6b6b6b" fontSize="10" textAnchor="middle">Gym</text>
+
+                <rect x="100" y="190" width="100" height="70" rx="4" />
+                <text x="150" y="230" fill="#6b6b6b" fontSize="10" textAnchor="middle">Science</text>
+
+                <rect x="230" y="180" width="90" height="80" rx="4" />
+                <text x="275" y="225" fill="#6b6b6b" fontSize="10" textAnchor="middle">Arts</text>
+              </g>
+
+              {/* Paths */}
+              <g stroke="#3a3a5a" strokeWidth="2" fill="none" strokeDasharray="4,4">
+                <path d="M170 120 L200 90" />
+                <path d="M170 130 L200 200 L230 220" />
+                <path d="M280 90 L300 150" />
+                <path d="M200 230 L230 220" />
+              </g>
+
+              {/* Line between guess and actual (Phase 2+) */}
+              {animationPhase >= 2 && (
+                <line
+                  className="result-line"
+                  x1={`${guessLocation.x}%`}
+                  y1={`${guessLocation.y}%`}
+                  x2={`${actualLocation.x}%`}
+                  y2={`${actualLocation.y}%`}
+                  stroke="#ffc107"
+                  strokeWidth="3"
+                  strokeDasharray="8,4"
+                />
+              )}
+            </svg>
+
+            {/* Guess marker (always visible) */}
+            <div
+              className="result-marker guess-marker"
+              style={{
+                left: `${guessLocation.x}%`,
+                top: `${guessLocation.y}%`
+              }}
+            >
+              <div className="marker-pin guess-pin"></div>
+              <div className="marker-label">Your guess</div>
+            </div>
+
+            {/* Actual location marker (Phase 1+) */}
+            {animationPhase >= 1 && (
+              <div
+                className="result-marker actual-marker"
+                style={{
+                  left: `${actualLocation.x}%`,
+                  top: `${actualLocation.y}%`
+                }}
+              >
+                <div className="marker-pin actual-pin"></div>
+                <div className="marker-label">Correct</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Side panel with details */}
+        <div className="result-details">
+          <div className="result-image-preview">
+            <img src={imageUrl} alt="Location" />
+          </div>
+
+          <div className="result-stats">
+            <div className="stat-row">
+              <span className="stat-icon">📍</span>
+              <span className="stat-label">Distance</span>
+              <span className="stat-value">{formatDistance(distance)}</span>
+            </div>
+
+            <div className="stat-row">
+              <span className="stat-icon">🏢</span>
+              <span className="stat-label">Floor</span>
+              <span className={`stat-value ${guessFloor === actualFloor ? 'correct' : 'incorrect'}`}>
+                {guessFloor === actualFloor ? (
+                  <>Correct! (Floor {actualFloor})</>
+                ) : (
+                  <>You: {guessFloor} | Actual: {actualFloor}</>
+                )}
+              </span>
+            </div>
+
+            <div className="score-breakdown">
+              <div className="breakdown-row">
+                <span>Location Score</span>
+                <span>{locationScore.toLocaleString()}</span>
+              </div>
+              {floorPenalty > 0 && (
+                <div className="breakdown-row penalty">
+                  <span>Wrong Floor (-20%)</span>
+                  <span>-{floorPenalty.toLocaleString()}</span>
+                </div>
+              )}
+              <div className="breakdown-row total">
+                <span>Total</span>
+                <span>{totalScore.toLocaleString()}</span>
+              </div>
+            </div>
+          </div>
+
+          <button
+            className="next-round-button"
+            onClick={isLastRound ? onViewFinalResults : onNextRound}
+          >
+            {isLastRound ? 'View Final Results' : 'Next Round'}
+            <span className="button-arrow">→</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="round-progress">
+        {[...Array(totalRounds)].map((_, i) => (
+          <div
+            key={i}
+            className={`progress-dot ${i < roundNumber ? 'completed' : ''} ${i === roundNumber - 1 ? 'current' : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ResultScreen;


### PR DESCRIPTION
## Summary
- Add **ResultScreen** component showing interactive map with guess vs actual location markers, animated line connecting them, and score breakdown
- Add **FinalResultsScreen** with performance ratings (Perfect/Excellent/Great/Good/etc.), animated score counter, confetti effects, and round-by-round breakdown
- Update **useGameState** hook for 5-round gameplay with comprehensive score tracking
- Implement GeoGuessr-style scoring: 0-5000 points based on distance (exponential decay), with 20% penalty for incorrect floor guesses
- Add round indicator badge on GameScreen
- Responsive design with smooth animations

## Test plan
- [ ] Start a new game and complete all 5 rounds
- [ ] Verify ResultScreen shows correct/guess markers on map with connecting line
- [ ] Verify score calculation: perfect location = 5000 pts, wrong floor = 20% penalty
- [ ] Verify FinalResultsScreen shows total score, performance rating, and round breakdown
- [ ] Test "Play Again" and "Back to Home" buttons
- [ ] Verify responsive layout on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)