### PR TITLE
Add Map Editor admin screen for drawing multi-floor region polygons

### DIFF
--- a/submission-app/src/App.css
+++ b/submission-app/src/App.css
@@ -20,7 +20,7 @@
   margin: 0;
 }
 
-.review-button {
+.admin-button {
   padding: 10px 25px;
   background-color: #3498db;
   color: white;
@@ -32,7 +32,7 @@
   transition: background-color 0.2s;
 }
 
-.review-button:hover {
+.admin-button:hover {
   background-color: #2980b9;
 }
 

--- a/submission-app/src/App.jsx
+++ b/submission-app/src/App.jsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 import './App.css'
 import SubmissionForm from './components/SubmissionForm'
-import AdminReview from './components/AdminReview'
+import AdminTabs from './components/AdminTabs'
 
 function App() {
-  const [showAdmin, setShowAdmin] = useState(false)
+  const [adminScreen, setAdminScreen] = useState(null) // null | 'review' | 'mapEditor'
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [passwordInput, setPasswordInput] = useState('')
   const [showPasswordPrompt, setShowPasswordPrompt] = useState(false)
@@ -12,9 +12,9 @@ function App() {
 
   const ADMIN_PASSWORD = '1234'
 
-  const handleReviewClick = () => {
+  const handleAdminClick = () => {
     if (isAuthenticated) {
-      setShowAdmin(true)
+      setAdminScreen('review')
     } else {
       setShowPasswordPrompt(true)
       setPasswordError('')
@@ -25,7 +25,7 @@ function App() {
     e.preventDefault()
     if (passwordInput === ADMIN_PASSWORD) {
       setIsAuthenticated(true)
-      setShowAdmin(true)
+      setAdminScreen('review')
       setShowPasswordPrompt(false)
       setPasswordInput('')
       setPasswordError('')
@@ -36,7 +36,7 @@ function App() {
   }
 
   const handleBackToSubmission = () => {
-    setShowAdmin(false)
+    setAdminScreen(null)
   }
 
   const handleCancelPassword = () => {
@@ -50,10 +50,10 @@ function App() {
       <header className="app-header">
         <h1>Photo Submission App</h1>
         <button
-          className="review-button"
-          onClick={handleReviewClick}
+          className="admin-button"
+          onClick={handleAdminClick}
         >
-          Review
+          Admin
         </button>
       </header>
 
@@ -80,8 +80,12 @@ function App() {
       )}
 
       <main className="app-main">
-        {showAdmin ? (
-          <AdminReview onBack={handleBackToSubmission} />
+        {adminScreen ? (
+          <AdminTabs
+            activeTab={adminScreen}
+            onTabChange={setAdminScreen}
+            onBack={handleBackToSubmission}
+          />
         ) : (
           <SubmissionForm />
         )}

--- a/submission-app/src/components/AdminReview.jsx
+++ b/submission-app/src/components/AdminReview.jsx
@@ -3,7 +3,7 @@ import { collection, query, orderBy, onSnapshot, doc, updateDoc, serverTimestamp
 import { db } from '../firebase'
 import './AdminReview.css'
 
-function AdminReview({ onBack }) {
+function AdminReview() {
   const [submissions, setSubmissions] = useState([])
   const [loading, setLoading] = useState(true)
   const [filter, setFilter] = useState('pending') // pending, approved, denied, all
@@ -78,13 +78,6 @@ function AdminReview({ onBack }) {
 
   return (
     <div className="admin-review">
-      <div className="admin-header">
-        <button className="back-button" onClick={onBack}>
-          ← Back to Submission
-        </button>
-        <h2>Admin Review Panel</h2>
-      </div>
-
       <div className="filter-tabs">
         <button
           className={`filter-tab ${filter === 'pending' ? 'active' : ''}`}

--- a/submission-app/src/components/AdminTabs.css
+++ b/submission-app/src/components/AdminTabs.css
@@ -1,0 +1,72 @@
+.admin-panel {
+  padding: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.admin-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.admin-panel-header h2 {
+  margin: 0;
+  color: #2c3e50;
+}
+
+.back-button {
+  padding: 10px 20px;
+  background-color: #95a5a6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.back-button:hover {
+  background-color: #7f8c8d;
+}
+
+.admin-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  border-bottom: 2px solid #e0e0e0;
+  padding-bottom: 0;
+}
+
+.admin-tab {
+  padding: 12px 24px;
+  border: none;
+  background-color: transparent;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  transition: all 0.2s;
+  position: relative;
+  bottom: -2px;
+  border-bottom: 2px solid transparent;
+}
+
+.admin-tab:hover {
+  background-color: #f8f9fa;
+  color: #333;
+}
+
+.admin-tab.active {
+  background-color: white;
+  color: #3498db;
+  border-bottom: 2px solid #3498db;
+}
+
+.admin-content {
+  background-color: white;
+  border-radius: 8px;
+  min-height: 500px;
+}

--- a/submission-app/src/components/AdminTabs.jsx
+++ b/submission-app/src/components/AdminTabs.jsx
@@ -1,0 +1,38 @@
+import './AdminTabs.css'
+import AdminReview from './AdminReview'
+import MapEditor from './MapEditor'
+
+function AdminTabs({ activeTab, onTabChange, onBack }) {
+  return (
+    <div className="admin-panel">
+      <div className="admin-panel-header">
+        <button className="back-button" onClick={onBack}>
+          ← Back to Submission
+        </button>
+        <h2>Admin Panel</h2>
+      </div>
+
+      <div className="admin-tabs">
+        <button
+          className={`admin-tab ${activeTab === 'review' ? 'active' : ''}`}
+          onClick={() => onTabChange('review')}
+        >
+          Review Submissions
+        </button>
+        <button
+          className={`admin-tab ${activeTab === 'mapEditor' ? 'active' : ''}`}
+          onClick={() => onTabChange('mapEditor')}
+        >
+          Map Editor
+        </button>
+      </div>
+
+      <div className="admin-content">
+        {activeTab === 'review' && <AdminReview />}
+        {activeTab === 'mapEditor' && <MapEditor />}
+      </div>
+    </div>
+  )
+}
+
+export default AdminTabs

--- a/submission-app/src/components/MapEditor.css
+++ b/submission-app/src/components/MapEditor.css
@@ -1,0 +1,74 @@
+.map-editor {
+  display: grid;
+  grid-template-columns: 1fr 350px;
+  gap: 20px;
+  height: calc(100vh - 220px);
+  min-height: 500px;
+}
+
+.map-editor-loading {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 18px;
+}
+
+.map-editor-error {
+  grid-column: 1 / -1;
+  background-color: #fee;
+  border: 1px solid #fcc;
+  border-radius: 4px;
+  padding: 12px 16px;
+  color: #c00;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.map-editor-error button {
+  background: none;
+  border: none;
+  color: #c00;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 5px;
+}
+
+.map-editor-canvas {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.map-editor-panel {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Responsive design */
+@media (max-width: 900px) {
+  .map-editor {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+    height: auto;
+  }
+
+  .map-editor-canvas {
+    min-height: 400px;
+  }
+
+  .map-editor-panel {
+    max-height: 400px;
+  }
+}

--- a/submission-app/src/components/MapEditor.jsx
+++ b/submission-app/src/components/MapEditor.jsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useCallback } from 'react'
+import { collection, query, orderBy, onSnapshot, doc, addDoc, updateDoc, deleteDoc, serverTimestamp } from 'firebase/firestore'
+import { db } from '../firebase'
+import PolygonDrawer from './PolygonDrawer'
+import RegionPanel from './RegionPanel'
+import './MapEditor.css'
+
+function MapEditor() {
+  const [regions, setRegions] = useState([])
+  const [selectedRegionId, setSelectedRegionId] = useState(null)
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [newPolygonPoints, setNewPolygonPoints] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // Fetch regions from Firestore
+  useEffect(() => {
+    const q = query(collection(db, 'regions'), orderBy('createdAt', 'desc'))
+
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const regs = snapshot.docs.map(doc => ({
+        id: doc.id,
+        ...doc.data()
+      }))
+      setRegions(regs)
+      setLoading(false)
+    }, (err) => {
+      console.error('Error fetching regions:', err)
+      setError('Failed to load regions')
+      setLoading(false)
+    })
+
+    return () => unsubscribe()
+  }, [])
+
+  const handleStartDrawing = useCallback(() => {
+    setIsDrawing(true)
+    setNewPolygonPoints([])
+    setSelectedRegionId(null)
+  }, [])
+
+  const handleCancelDrawing = useCallback(() => {
+    setIsDrawing(false)
+    setNewPolygonPoints([])
+  }, [])
+
+  const handlePointAdd = useCallback((point) => {
+    setNewPolygonPoints(prev => [...prev, point])
+  }, [])
+
+  const handlePolygonComplete = useCallback(async () => {
+    if (newPolygonPoints.length < 3) return
+
+    try {
+      const newRegion = {
+        name: `Region ${regions.length + 1}`,
+        polygon: newPolygonPoints,
+        floors: [1],
+        color: getRandomColor(),
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+      }
+
+      const docRef = await addDoc(collection(db, 'regions'), newRegion)
+      setSelectedRegionId(docRef.id)
+      setIsDrawing(false)
+      setNewPolygonPoints([])
+    } catch (err) {
+      console.error('Error saving region:', err)
+      setError('Failed to save region')
+    }
+  }, [newPolygonPoints, regions.length])
+
+  const handleRegionSelect = useCallback((id) => {
+    if (!isDrawing) {
+      setSelectedRegionId(id)
+    }
+  }, [isDrawing])
+
+  const handleRegionUpdate = useCallback(async (id, updates) => {
+    try {
+      await updateDoc(doc(db, 'regions', id), {
+        ...updates,
+        updatedAt: serverTimestamp()
+      })
+    } catch (err) {
+      console.error('Error updating region:', err)
+      setError('Failed to update region')
+    }
+  }, [])
+
+  const handleRegionDelete = useCallback(async (id) => {
+    try {
+      await deleteDoc(doc(db, 'regions', id))
+      if (selectedRegionId === id) {
+        setSelectedRegionId(null)
+      }
+    } catch (err) {
+      console.error('Error deleting region:', err)
+      setError('Failed to delete region')
+    }
+  }, [selectedRegionId])
+
+  const handlePointMove = useCallback(async (regionId, pointIndex, newPosition) => {
+    const region = regions.find(r => r.id === regionId)
+    if (!region) return
+
+    const updatedPolygon = [...region.polygon]
+    updatedPolygon[pointIndex] = newPosition
+
+    try {
+      await updateDoc(doc(db, 'regions', regionId), {
+        polygon: updatedPolygon,
+        updatedAt: serverTimestamp()
+      })
+    } catch (err) {
+      console.error('Error moving point:', err)
+      setError('Failed to update region')
+    }
+  }, [regions])
+
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && isDrawing) {
+        handleCancelDrawing()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isDrawing, handleCancelDrawing])
+
+  if (loading) {
+    return (
+      <div className="map-editor">
+        <div className="map-editor-loading">Loading regions...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="map-editor">
+      {error && (
+        <div className="map-editor-error">
+          {error}
+          <button onClick={() => setError(null)}>×</button>
+        </div>
+      )}
+
+      <div className="map-editor-canvas">
+        <PolygonDrawer
+          regions={regions}
+          selectedRegionId={selectedRegionId}
+          isDrawing={isDrawing}
+          newPolygonPoints={newPolygonPoints}
+          onRegionSelect={handleRegionSelect}
+          onPointAdd={handlePointAdd}
+          onPolygonComplete={handlePolygonComplete}
+          onPointMove={handlePointMove}
+        />
+      </div>
+
+      <div className="map-editor-panel">
+        <RegionPanel
+          regions={regions}
+          selectedRegionId={selectedRegionId}
+          onRegionSelect={handleRegionSelect}
+          onRegionUpdate={handleRegionUpdate}
+          onRegionDelete={handleRegionDelete}
+          onStartDrawing={handleStartDrawing}
+          onCancelDrawing={handleCancelDrawing}
+          isDrawing={isDrawing}
+          newPolygonPoints={newPolygonPoints}
+        />
+      </div>
+    </div>
+  )
+}
+
+// Helper function to generate random colors
+function getRandomColor() {
+  const colors = [
+    '#4a90d9', '#e74c3c', '#27ae60', '#9b59b6',
+    '#f39c12', '#1abc9c', '#e67e22', '#3498db'
+  ]
+  return colors[Math.floor(Math.random() * colors.length)]
+}
+
+export default MapEditor

--- a/submission-app/src/components/PolygonDrawer.css
+++ b/submission-app/src/components/PolygonDrawer.css
@@ -1,0 +1,80 @@
+.polygon-drawer-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  background-color: #f5f5f5;
+}
+
+.polygon-drawer-svg {
+  width: 100%;
+  height: 100%;
+  cursor: default;
+}
+
+.polygon-drawer-svg.drawing-mode {
+  cursor: crosshair;
+}
+
+/* Polygon styling */
+.region-polygon {
+  cursor: pointer;
+  transition: fill-opacity 0.2s, stroke-width 0.2s;
+}
+
+.region-polygon:hover {
+  fill-opacity: 0.4;
+}
+
+/* Vertex handles */
+.polygon-vertex {
+  cursor: move;
+  transition: r 0.15s, fill 0.15s;
+}
+
+.polygon-vertex:hover {
+  r: 10;
+  fill: #3498db;
+}
+
+/* Drawing vertices */
+.drawing-vertex {
+  transition: r 0.15s;
+}
+
+.first-vertex {
+  cursor: pointer;
+}
+
+.first-vertex:hover {
+  r: 12;
+}
+
+/* Region label */
+.region-label {
+  text-shadow:
+    1px 1px 2px white,
+    -1px -1px 2px white,
+    1px -1px 2px white,
+    -1px 1px 2px white;
+}
+
+/* Empty state overlay */
+.polygon-drawer-empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #999;
+  pointer-events: none;
+}
+
+.polygon-drawer-empty p {
+  margin: 8px 0;
+  font-size: 16px;
+}
+
+.polygon-drawer-empty p:first-child {
+  font-size: 18px;
+  color: #666;
+}

--- a/submission-app/src/components/PolygonDrawer.jsx
+++ b/submission-app/src/components/PolygonDrawer.jsx
@@ -1,0 +1,263 @@
+import { useRef, useState, useCallback } from 'react'
+import './PolygonDrawer.css'
+
+const VIEWBOX_WIDTH = 800
+const VIEWBOX_HEIGHT = 600
+const CLOSE_THRESHOLD = 15 // Distance to first point to close polygon
+
+function PolygonDrawer({
+  regions,
+  selectedRegionId,
+  isDrawing,
+  newPolygonPoints,
+  onRegionSelect,
+  onPointAdd,
+  onPolygonComplete,
+  onPointMove
+}) {
+  const svgRef = useRef(null)
+  const [draggingPoint, setDraggingPoint] = useState(null)
+  const [hoverFirstPoint, setHoverFirstPoint] = useState(false)
+
+  // Convert screen coordinates to SVG viewBox coordinates
+  const getViewBoxCoords = useCallback((e) => {
+    if (!svgRef.current) return null
+
+    const rect = svgRef.current.getBoundingClientRect()
+    const x = (e.clientX - rect.left) * (VIEWBOX_WIDTH / rect.width)
+    const y = (e.clientY - rect.top) * (VIEWBOX_HEIGHT / rect.height)
+
+    return {
+      x: Math.round(Math.max(0, Math.min(VIEWBOX_WIDTH, x))),
+      y: Math.round(Math.max(0, Math.min(VIEWBOX_HEIGHT, y)))
+    }
+  }, [])
+
+  // Handle click on the SVG canvas
+  const handleSvgClick = useCallback((e) => {
+    // Ignore if we're dragging or clicked on a control element
+    if (draggingPoint || e.target.closest('.polygon-vertex')) return
+
+    const coords = getViewBoxCoords(e)
+    if (!coords) return
+
+    if (isDrawing) {
+      // Check if clicking near the first point to close polygon
+      if (newPolygonPoints.length >= 3) {
+        const first = newPolygonPoints[0]
+        const distance = Math.sqrt(
+          Math.pow(coords.x - first.x, 2) + Math.pow(coords.y - first.y, 2)
+        )
+        if (distance < CLOSE_THRESHOLD) {
+          onPolygonComplete()
+          return
+        }
+      }
+      onPointAdd(coords)
+    }
+  }, [isDrawing, newPolygonPoints, draggingPoint, getViewBoxCoords, onPointAdd, onPolygonComplete])
+
+  // Handle mouse move for hover effects and dragging
+  const handleMouseMove = useCallback((e) => {
+    const coords = getViewBoxCoords(e)
+    if (!coords) return
+
+    // Update hover state for first point
+    if (isDrawing && newPolygonPoints.length >= 3) {
+      const first = newPolygonPoints[0]
+      const distance = Math.sqrt(
+        Math.pow(coords.x - first.x, 2) + Math.pow(coords.y - first.y, 2)
+      )
+      setHoverFirstPoint(distance < CLOSE_THRESHOLD)
+    } else {
+      setHoverFirstPoint(false)
+    }
+
+    // Handle point dragging
+    if (draggingPoint) {
+      onPointMove(draggingPoint.regionId, draggingPoint.pointIndex, coords)
+    }
+  }, [isDrawing, newPolygonPoints, draggingPoint, getViewBoxCoords, onPointMove])
+
+  // Start dragging a vertex
+  const handleVertexMouseDown = useCallback((e, regionId, pointIndex) => {
+    e.stopPropagation()
+    setDraggingPoint({ regionId, pointIndex })
+  }, [])
+
+  // Stop dragging
+  const handleMouseUp = useCallback(() => {
+    setDraggingPoint(null)
+  }, [])
+
+  // Generate polygon points string
+  const getPolygonPointsString = (points) => {
+    return points.map(p => `${p.x},${p.y}`).join(' ')
+  }
+
+  return (
+    <div className="polygon-drawer-container">
+      <svg
+        ref={svgRef}
+        className={`polygon-drawer-svg ${isDrawing ? 'drawing-mode' : ''}`}
+        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        preserveAspectRatio="xMidYMid meet"
+        onClick={handleSvgClick}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        {/* Map background */}
+        <image
+          href="/template-map.png"
+          width={VIEWBOX_WIDTH}
+          height={VIEWBOX_HEIGHT}
+          preserveAspectRatio="xMidYMid slice"
+        />
+
+        {/* Fallback if no map image - grid pattern */}
+        <defs>
+          <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
+            <path d="M 50 0 L 0 0 0 50" fill="none" stroke="#e0e0e0" strokeWidth="0.5" />
+          </pattern>
+        </defs>
+
+        {/* Existing regions */}
+        {regions.map(region => (
+          <g key={region.id} className="region-group">
+            {/* Polygon fill */}
+            <polygon
+              points={getPolygonPointsString(region.polygon)}
+              fill={region.color || '#4a90d9'}
+              fillOpacity={selectedRegionId === region.id ? 0.5 : 0.3}
+              stroke={selectedRegionId === region.id ? '#2c3e50' : region.color || '#4a90d9'}
+              strokeWidth={selectedRegionId === region.id ? 3 : 2}
+              className="region-polygon"
+              onClick={(e) => {
+                e.stopPropagation()
+                onRegionSelect(region.id)
+              }}
+            />
+
+            {/* Vertex handles for selected region */}
+            {selectedRegionId === region.id && region.polygon.map((point, i) => (
+              <circle
+                key={i}
+                cx={point.x}
+                cy={point.y}
+                r={8}
+                fill="white"
+                stroke="#2c3e50"
+                strokeWidth={2}
+                className="polygon-vertex"
+                style={{ cursor: 'move' }}
+                onMouseDown={(e) => handleVertexMouseDown(e, region.id, i)}
+              />
+            ))}
+
+            {/* Region label */}
+            {region.polygon.length > 0 && (
+              <text
+                x={getCentroid(region.polygon).x}
+                y={getCentroid(region.polygon).y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#2c3e50"
+                fontSize="14"
+                fontWeight="bold"
+                className="region-label"
+                pointerEvents="none"
+              >
+                {region.name}
+              </text>
+            )}
+          </g>
+        ))}
+
+        {/* In-progress polygon while drawing */}
+        {isDrawing && newPolygonPoints.length > 0 && (
+          <g className="drawing-group">
+            {/* Lines connecting points */}
+            <polyline
+              points={getPolygonPointsString(newPolygonPoints)}
+              fill="none"
+              stroke="#3498db"
+              strokeWidth={2}
+              strokeDasharray="8,4"
+            />
+
+            {/* Preview line to cursor would go here if we tracked cursor position */}
+
+            {/* Vertex circles */}
+            {newPolygonPoints.map((point, i) => (
+              <circle
+                key={i}
+                cx={point.x}
+                cy={point.y}
+                r={i === 0 ? (hoverFirstPoint ? 12 : 10) : 6}
+                fill={i === 0 ? (hoverFirstPoint ? '#27ae60' : '#2ecc71') : '#3498db'}
+                stroke="white"
+                strokeWidth={2}
+                className={`drawing-vertex ${i === 0 ? 'first-vertex' : ''}`}
+              />
+            ))}
+
+            {/* Close hint text */}
+            {newPolygonPoints.length >= 3 && (
+              <text
+                x={newPolygonPoints[0].x}
+                y={newPolygonPoints[0].y - 20}
+                textAnchor="middle"
+                fill="#27ae60"
+                fontSize="12"
+                fontWeight="bold"
+              >
+                Click to close
+              </text>
+            )}
+          </g>
+        )}
+
+        {/* Drawing mode hint */}
+        {isDrawing && newPolygonPoints.length === 0 && (
+          <text
+            x={VIEWBOX_WIDTH / 2}
+            y={30}
+            textAnchor="middle"
+            fill="#3498db"
+            fontSize="16"
+            fontWeight="bold"
+          >
+            Click on the map to add points. Click first point to close.
+          </text>
+        )}
+      </svg>
+
+      {/* Instructions overlay */}
+      {!isDrawing && regions.length === 0 && (
+        <div className="polygon-drawer-empty">
+          <p>No regions defined yet.</p>
+          <p>Click "New Region" to start drawing.</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Calculate centroid of polygon for label placement
+function getCentroid(points) {
+  if (points.length === 0) return { x: 0, y: 0 }
+
+  let sumX = 0
+  let sumY = 0
+  for (const point of points) {
+    sumX += point.x
+    sumY += point.y
+  }
+  return {
+    x: sumX / points.length,
+    y: sumY / points.length
+  }
+}
+
+export default PolygonDrawer

--- a/submission-app/src/components/RegionPanel.css
+++ b/submission-app/src/components/RegionPanel.css
@@ -1,0 +1,317 @@
+.region-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Toolbar */
+.region-panel-toolbar {
+  padding: 15px;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.new-region-button {
+  flex: 1;
+  padding: 12px 20px;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.new-region-button:hover {
+  background-color: #2980b9;
+}
+
+.drawing-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #27ae60;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.drawing-indicator {
+  width: 10px;
+  height: 10px;
+  background-color: #27ae60;
+  border-radius: 50%;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.cancel-drawing-button {
+  padding: 10px 16px;
+  background-color: #95a5a6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.cancel-drawing-button:hover {
+  background-color: #7f8c8d;
+}
+
+/* Region list */
+.region-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 15px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.region-list h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.no-regions {
+  color: #999;
+  font-size: 14px;
+  text-align: center;
+  padding: 20px 0;
+}
+
+.region-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.region-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  margin-bottom: 4px;
+}
+
+.region-item:hover {
+  background-color: #f5f5f5;
+}
+
+.region-item.selected {
+  background-color: #e3f2fd;
+  border: 1px solid #bbdefb;
+}
+
+.region-color-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.region-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.region-item-name {
+  font-weight: 600;
+  color: #333;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.region-item-floors {
+  font-size: 12px;
+  color: #666;
+}
+
+/* Region editor */
+.region-editor {
+  padding: 15px;
+  background-color: #fafafa;
+  border-top: 1px solid #e0e0e0;
+}
+
+.region-editor h3 {
+  margin: 0 0 15px 0;
+  font-size: 14px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 6px;
+}
+
+.form-group input[type="text"] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.form-group input[type="text"]:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+/* Floor toggles */
+.floor-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.floor-toggle {
+  width: 36px;
+  height: 32px;
+  border: 1px solid #ddd;
+  background-color: white;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: #666;
+}
+
+.floor-toggle:hover {
+  background-color: #f0f0f0;
+  border-color: #ccc;
+}
+
+.floor-toggle.active {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: white;
+}
+
+.floor-hint {
+  display: block;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #888;
+}
+
+/* Color presets */
+.color-presets {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.color-preset {
+  width: 32px;
+  height: 32px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.15s, border-color 0.15s;
+}
+
+.color-preset:hover {
+  transform: scale(1.1);
+}
+
+.color-preset.active {
+  border-color: #2c3e50;
+  box-shadow: 0 0 0 2px white, 0 0 0 4px #2c3e50;
+}
+
+/* Editor actions */
+.editor-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.save-button {
+  flex: 1;
+  padding: 10px 16px;
+  background-color: #27ae60;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.save-button:hover {
+  background-color: #219a52;
+}
+
+.delete-button {
+  padding: 10px 16px;
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.delete-button:hover {
+  background-color: #c0392b;
+}
+
+.delete-button.confirm {
+  background-color: #c0392b;
+  animation: shake 0.3s;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}
+
+/* Hint panel */
+.region-panel-hint {
+  padding: 20px;
+  text-align: center;
+  color: #888;
+}
+
+.region-panel-hint p {
+  margin: 0;
+  font-size: 14px;
+}

--- a/submission-app/src/components/RegionPanel.jsx
+++ b/submission-app/src/components/RegionPanel.jsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from 'react'
+import './RegionPanel.css'
+
+// Floor range for toggle buttons
+const FLOOR_OPTIONS = [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+// Preset colors for regions
+const COLOR_PRESETS = [
+  '#4a90d9', '#e74c3c', '#27ae60', '#9b59b6',
+  '#f39c12', '#1abc9c', '#e67e22', '#34495e'
+]
+
+function RegionPanel({
+  regions,
+  selectedRegionId,
+  onRegionSelect,
+  onRegionUpdate,
+  onRegionDelete,
+  onStartDrawing,
+  onCancelDrawing,
+  isDrawing,
+  newPolygonPoints
+}) {
+  const [editName, setEditName] = useState('')
+  const [editFloors, setEditFloors] = useState([])
+  const [editColor, setEditColor] = useState('')
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+  const selectedRegion = regions.find(r => r.id === selectedRegionId)
+
+  // Update edit state when selection changes
+  useEffect(() => {
+    if (selectedRegion) {
+      setEditName(selectedRegion.name || '')
+      setEditFloors(selectedRegion.floors || [1])
+      setEditColor(selectedRegion.color || '#4a90d9')
+      setShowDeleteConfirm(false)
+    }
+  }, [selectedRegion])
+
+  const handleSave = () => {
+    if (!selectedRegionId) return
+
+    onRegionUpdate(selectedRegionId, {
+      name: editName,
+      floors: editFloors.sort((a, b) => a - b),
+      color: editColor
+    })
+  }
+
+  const handleFloorToggle = (floor) => {
+    setEditFloors(prev => {
+      if (prev.includes(floor)) {
+        // Remove floor (but keep at least one)
+        const newFloors = prev.filter(f => f !== floor)
+        return newFloors.length > 0 ? newFloors : prev
+      } else {
+        // Add floor
+        return [...prev, floor].sort((a, b) => a - b)
+      }
+    })
+  }
+
+  const handleDelete = () => {
+    if (showDeleteConfirm) {
+      onRegionDelete(selectedRegionId)
+      setShowDeleteConfirm(false)
+    } else {
+      setShowDeleteConfirm(true)
+    }
+  }
+
+  const formatFloors = (floors) => {
+    if (!floors || floors.length === 0) return 'None'
+    const sorted = [...floors].sort((a, b) => a - b)
+    if (sorted.length === 1) return `Floor ${sorted[0]}`
+    return `Floors ${sorted.join(', ')}`
+  }
+
+  return (
+    <div className="region-panel">
+      {/* Toolbar */}
+      <div className="region-panel-toolbar">
+        {isDrawing ? (
+          <>
+            <div className="drawing-status">
+              <span className="drawing-indicator"></span>
+              Drawing: {newPolygonPoints.length} points
+            </div>
+            <button
+              className="cancel-drawing-button"
+              onClick={onCancelDrawing}
+            >
+              Cancel (Esc)
+            </button>
+          </>
+        ) : (
+          <button
+            className="new-region-button"
+            onClick={onStartDrawing}
+          >
+            + New Region
+          </button>
+        )}
+      </div>
+
+      {/* Region list */}
+      <div className="region-list">
+        <h3>Regions ({regions.length})</h3>
+        {regions.length === 0 ? (
+          <p className="no-regions">No regions yet. Create one to get started.</p>
+        ) : (
+          <ul>
+            {regions.map(region => (
+              <li
+                key={region.id}
+                className={`region-item ${selectedRegionId === region.id ? 'selected' : ''}`}
+                onClick={() => onRegionSelect(region.id)}
+              >
+                <span
+                  className="region-color-swatch"
+                  style={{ backgroundColor: region.color || '#4a90d9' }}
+                />
+                <div className="region-item-info">
+                  <span className="region-item-name">{region.name}</span>
+                  <span className="region-item-floors">
+                    {formatFloors(region.floors)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Region editor */}
+      {selectedRegion && (
+        <div className="region-editor">
+          <h3>Edit Region</h3>
+
+          <div className="form-group">
+            <label htmlFor="region-name">Name</label>
+            <input
+              id="region-name"
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              placeholder="Region name"
+            />
+          </div>
+
+          <div className="form-group">
+            <label>Floors</label>
+            <div className="floor-toggles">
+              {FLOOR_OPTIONS.map(floor => (
+                <button
+                  key={floor}
+                  className={`floor-toggle ${editFloors.includes(floor) ? 'active' : ''}`}
+                  onClick={() => handleFloorToggle(floor)}
+                  title={floor < 0 ? `Basement ${Math.abs(floor)}` : `Floor ${floor}`}
+                >
+                  {floor < 0 ? `B${Math.abs(floor)}` : floor}
+                </button>
+              ))}
+            </div>
+            <span className="floor-hint">
+              Selected: {editFloors.sort((a, b) => a - b).join(', ') || 'None'}
+            </span>
+          </div>
+
+          <div className="form-group">
+            <label>Color</label>
+            <div className="color-presets">
+              {COLOR_PRESETS.map(color => (
+                <button
+                  key={color}
+                  className={`color-preset ${editColor === color ? 'active' : ''}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setEditColor(color)}
+                  title={color}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="editor-actions">
+            <button className="save-button" onClick={handleSave}>
+              Save Changes
+            </button>
+            <button
+              className={`delete-button ${showDeleteConfirm ? 'confirm' : ''}`}
+              onClick={handleDelete}
+              onBlur={() => setShowDeleteConfirm(false)}
+            >
+              {showDeleteConfirm ? 'Click again to confirm' : 'Delete'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Instructions when nothing selected */}
+      {!selectedRegion && !isDrawing && regions.length > 0 && (
+        <div className="region-panel-hint">
+          <p>Click on a region in the list or on the map to edit it.</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RegionPanel


### PR DESCRIPTION
## Summary
- Adds a new **Map Editor** tab to the admin panel for drawing polygon regions on the campus map
- Allows defining multi-floor building areas with individual floor selection (supports floors -2 to 10)
- Implements SVG-based polygon drawing with intuitive click-to-draw and drag-to-edit interactions
- Persists regions to Firestore `regions` collection with real-time sync

## New Components
- `AdminTabs` - Tab navigation between Review Submissions and Map Editor
- `MapEditor` - Main container with two-column layout
- `PolygonDrawer` - SVG canvas for drawing and editing polygons
- `RegionPanel` - Side panel for region list and editing (name, floors, color)

## How to Test
1. Run `cd submission-app && npm run dev`
2. Click "Admin" → enter password "1234"
3. Click "Map Editor" tab
4. Click "New Region" → click on map to add points → click first point to close
5. Edit region properties in the side panel and click "Save Changes"

## Test plan
- [ ] Verify admin tab navigation works (switching between Review and Map Editor)
- [ ] Test polygon drawing: add points, close polygon by clicking first point
- [ ] Test polygon editing: select region, drag vertices, save changes
- [ ] Test floor toggle selection (individual floors can be selected/deselected)
- [ ] Test region delete functionality
- [ ] Verify existing AdminReview functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)