### PR TITLE
Add playing area restriction feature to map editor

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -22,6 +22,8 @@ function App() {
     roundResults,
     isLoading,
     error,
+    clickRejected,
+    playingArea,
     startGame,
     placeMarker,
     selectFloor,
@@ -80,6 +82,8 @@ function App() {
           onBackToTitle={resetGame}
           currentRound={currentRound}
           totalRounds={totalRounds}
+          clickRejected={clickRejected}
+          playingArea={playingArea}
         />
       )}
 

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -14,7 +14,9 @@ function GameScreen({
   onSubmitGuess,
   onBackToTitle,
   currentRound = 1,
-  totalRounds = 5
+  totalRounds = 5,
+  clickRejected = false,
+  playingArea = null
 }) {
   // Can submit if location is selected AND either:
   // - not in a region (availableFloors is null), OR
@@ -46,6 +48,8 @@ function GameScreen({
           <MapPicker
             markerPosition={guessLocation}
             onMapClick={onMapClick}
+            clickRejected={clickRejected}
+            playingArea={playingArea}
           />
 
           {isInRegion && (

--- a/react-vite-app/src/components/MapPicker/MapPicker.css
+++ b/react-vite-app/src/components/MapPicker/MapPicker.css
@@ -107,6 +107,56 @@
   }
 }
 
+/* Playing regions overlay */
+.playing-regions-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+/* Click rejected feedback */
+.map-picker.click-rejected {
+  animation: rejectShake 0.4s ease-in-out;
+  border-color: #e74c3c !important;
+}
+
+@keyframes rejectShake {
+  0%, 100% {
+    transform: translateX(0);
+  }
+  10%, 30%, 50%, 70%, 90% {
+    transform: translateX(-4px);
+  }
+  20%, 40%, 60%, 80% {
+    transform: translateX(4px);
+  }
+}
+
+/* Flash overlay for rejected clicks */
+.map-picker.click-rejected::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(231, 76, 60, 0.2);
+  pointer-events: none;
+  animation: rejectFlash 0.4s ease-out forwards;
+}
+
+@keyframes rejectFlash {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .map-picker {

--- a/react-vite-app/src/components/MapPicker/MapPicker.jsx
+++ b/react-vite-app/src/components/MapPicker/MapPicker.jsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import './MapPicker.css';
 
-function MapPicker({ markerPosition, onMapClick }) {
+function MapPicker({ markerPosition, onMapClick, clickRejected = false, playingArea = null }) {
   const imageRef = useRef(null);
 
   const handleClick = (event) => {
@@ -19,19 +19,63 @@ function MapPicker({ markerPosition, onMapClick }) {
     onMapClick({ x: clampedX, y: clampedY });
   };
 
+  // Check if playing area is defined
+  const hasPlayingArea = playingArea && playingArea.polygon && playingArea.polygon.length >= 3;
+
   return (
     <div className="map-picker-container">
       <div className="map-header">
         <span className="map-icon">🗺️</span>
         <span>Click to place your guess</span>
       </div>
-      <div className="map-picker" onClick={handleClick}>
+      <div className={`map-picker ${clickRejected ? 'click-rejected' : ''}`} onClick={handleClick}>
         <img
           ref={imageRef}
           className="map-image"
           src="/map.png"
           alt="Campus Map"
         />
+
+        {/* SVG overlay showing playing area - darkens outside area */}
+        {hasPlayingArea && (
+          <svg
+            className="playing-regions-overlay"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+          >
+            <defs>
+              {/* Define the playing area as a mask - white = visible, black = hidden */}
+              <mask id="playing-area-mask">
+                {/* Start with white background (everything visible) */}
+                <rect x="0" y="0" width="100" height="100" fill="white" />
+                {/* Cut out the playing area (make it black = hidden from dark overlay) */}
+                <polygon
+                  points={playingArea.polygon.map(p => `${p.x},${p.y}`).join(' ')}
+                  fill="black"
+                />
+              </mask>
+            </defs>
+
+            {/* Dark overlay outside the playing area */}
+            <rect
+              x="0"
+              y="0"
+              width="100"
+              height="100"
+              fill="rgba(0, 0, 0, 0.5)"
+              mask="url(#playing-area-mask)"
+            />
+
+            {/* Border around the playing area */}
+            <polygon
+              points={playingArea.polygon.map(p => `${p.x},${p.y}`).join(' ')}
+              fill="none"
+              stroke="#27ae60"
+              strokeWidth="0.4"
+              strokeOpacity="0.8"
+            />
+          </svg>
+        )}
 
         {/* Marker - positioned relative to the container which matches image size */}
         {markerPosition && (

--- a/react-vite-app/src/components/SubmissionApp/PolygonDrawer.css
+++ b/react-vite-app/src/components/SubmissionApp/PolygonDrawer.css
@@ -45,6 +45,15 @@
   pointer-events: none;
 }
 
+.polygon-drawer-hint.playing-area {
+  background-color: rgba(39, 174, 96, 0.9);
+}
+
+/* Playing area polygon styling */
+.playing-area-polygon {
+  pointer-events: none;
+}
+
 /* Polygon styling */
 .region-polygon {
   cursor: pointer;

--- a/react-vite-app/src/components/SubmissionApp/RegionPanel.css
+++ b/react-vite-app/src/components/SubmissionApp/RegionPanel.css
@@ -317,3 +317,118 @@
   margin: 0;
   font-size: 14px;
 }
+
+/* Playing Area Section */
+.playing-area-section {
+  padding: 15px;
+  border-bottom: 1px solid var(--border-color, #3a3a5a);
+  background-color: var(--bg-card, #1a1a2e);
+}
+
+.playing-area-section h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: var(--text-secondary, #a0a0a0);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.playing-area-info {
+  padding: 10px;
+  background-color: rgba(39, 174, 96, 0.1);
+  border: 1px solid rgba(39, 174, 96, 0.3);
+  border-radius: 6px;
+}
+
+.playing-area-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #27ae60;
+  margin-bottom: 6px;
+}
+
+.playing-area-icon {
+  font-size: 12px;
+}
+
+.playing-area-hint {
+  margin: 0 0 10px 0;
+  font-size: 12px;
+  color: var(--text-muted, #666);
+}
+
+.playing-area-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.redraw-button {
+  flex: 1;
+  padding: 8px 12px;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.redraw-button:hover:not(:disabled) {
+  background-color: #2980b9;
+}
+
+.redraw-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.delete-button.small {
+  padding: 8px 12px;
+  font-size: 13px;
+}
+
+.no-playing-area {
+  text-align: center;
+  padding: 10px;
+}
+
+.no-playing-area p {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: var(--text-muted, #666);
+}
+
+.draw-playing-area-button {
+  width: 100%;
+  padding: 12px 20px;
+  background-color: #27ae60;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.draw-playing-area-button:hover:not(:disabled) {
+  background-color: #219a52;
+}
+
+.draw-playing-area-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.drawing-active {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.drawing-status.playing-area {
+  color: #27ae60;
+}

--- a/react-vite-app/src/services/regionService.js
+++ b/react-vite-app/src/services/regionService.js
@@ -1,4 +1,4 @@
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 
 /**
@@ -20,6 +20,26 @@ export async function getRegions() {
   } catch (error) {
     console.error('Error fetching regions:', error);
     return [];
+  }
+}
+
+/**
+ * Fetches the playing area from Firestore settings
+ * @returns {Object|null} - Playing area object with polygon, or null if not defined
+ */
+export async function getPlayingArea() {
+  try {
+    const playingAreaRef = doc(db, 'settings', 'playingArea');
+    const docSnap = await getDoc(playingAreaRef);
+
+    if (docSnap.exists()) {
+      return docSnap.data();
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error fetching playing area:', error);
+    return null;
   }
 }
 
@@ -68,4 +88,19 @@ export function getFloorsForPoint(point, regions) {
   }
 
   return null;
+}
+
+/**
+ * Check if a point is inside the playing area
+ * @param {Object} point - {x, y} coordinates (0-100 percentage)
+ * @param {Object|null} playingArea - Playing area object with polygon property
+ * @returns {boolean} - True if point is inside the playing area (or no playing area defined)
+ */
+export function isPointInPlayingArea(point, playingArea) {
+  // If no playing area is defined, allow clicks anywhere
+  if (!playingArea || !playingArea.polygon || playingArea.polygon.length < 3) {
+    return true;
+  }
+
+  return isPointInPolygon(point, playingArea.polygon);
 }


### PR DESCRIPTION
## Summary
- Add separate "Playing Area" section in map editor to define where players can click during gameplay
- Playing area is stored separately from floor regions in Firestore (`settings/playingArea`)
- Display playing area with dark overlay outside the boundary during gameplay
- Show shake animation and red flash when clicking outside playing area
- Floor regions remain independent for floor selection functionality

## Test plan
- [ ] Open the map editor and click "Draw Playing Area"
- [ ] Draw a polygon to define the playing boundary
- [ ] Verify the playing area is saved and displayed with a green dashed border
- [ ] Start a new game and verify:
  - [ ] Area outside the playing boundary is darkened
  - [ ] Clicking inside the playing area works normally
  - [ ] Clicking outside the playing area shows shake animation and red flash
  - [ ] Floor selection still works for floor regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)