### PR TITLE
Fix playing area not being loaded when starting game

### DIFF
--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -114,7 +114,15 @@ export function useGameState() {
     setError(null);
 
     try {
-      const image = await getRandomImage();
+      // Reload playing area and regions in case they were updated in the editor
+      const [image, fetchedPlayingArea, fetchedRegions] = await Promise.all([
+        getRandomImage(),
+        getPlayingArea(),
+        getRegions()
+      ]);
+
+      setPlayingArea(fetchedPlayingArea);
+      setRegions(fetchedRegions);
       setCurrentImage(image);
       setGuessLocation(null);
       setGuessFloor(null);


### PR DESCRIPTION
## Summary
- Fix bug where the playing area restriction was not working in gameplay
- Reload playing area and regions from Firestore when starting a new game
- This ensures changes made in the map editor are reflected in gameplay

## Test plan
- [ ] Create a playing area in the map editor
- [ ] Go back to the title screen and start a new game
- [ ] Verify the dark overlay appears outside the playing area
- [ ] Verify clicking outside the playing area is rejected with shake animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)