### PR TITLE
Replace upload location picker with game-style MapPicker and FloorSelector

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.css
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.css
@@ -30,35 +30,64 @@
   text-align: center;
 }
 
-.floor-input {
+.location-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-bottom: 30px;
 }
 
-.floor-input h3 {
-  margin-bottom: 10px;
-  color: #333;
+/* Override checkbox control */
+.override-control {
+  padding: 0 0.25rem;
 }
 
-.floor-input input {
-  width: 100%;
-  max-width: 200px;
-  padding: 12px 15px;
-  font-size: 16px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  transition: border-color 0.2s;
+.override-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--text-primary, #333);
 }
 
-.floor-input input:focus {
-  outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+.override-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--accent-green, #27ae60);
 }
 
-.floor-hint {
-  font-size: 12px;
-  color: #999;
-  margin-top: 5px;
+.override-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #999);
+  margin: 0.25rem 0 0 1.6rem;
+}
+
+/* Status indicators */
+.location-status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0 0.25rem;
+}
+
+.location-status .status-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #999);
+}
+
+.location-status .status-item.complete {
+  color: var(--accent-green, #27ae60);
+}
+
+.location-status .status-icon {
+  font-size: 0.9rem;
+  width: 1.2em;
+  text-align: center;
 }
 
 .submit-button {

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
@@ -1,18 +1,45 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { db, storage } from '../../firebase'
-import MapSelector from './MapSelector'
+import { getRegions, getPlayingArea, getFloorsForPoint, isPointInPlayingArea } from '../../services/regionService'
+import MapPicker from '../MapPicker/MapPicker'
+import FloorSelector from '../FloorSelector/FloorSelector'
 import PhotoUpload from './PhotoUpload'
 import './SubmissionForm.css'
+
+// All possible floors when override is enabled
+const ALL_FLOORS = [1, 2, 3]
 
 function SubmissionForm() {
   const [photo, setPhoto] = useState(null)
   const [location, setLocation] = useState(null)
-  const [floor, setFloor] = useState('')
+  const [floor, setFloor] = useState(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitSuccess, setSubmitSuccess] = useState(false)
   const [submitError, setSubmitError] = useState('')
+
+  // Region/playing area state (matching game behavior)
+  const [regions, setRegions] = useState([])
+  const [playingArea, setPlayingArea] = useState(null)
+  const [availableFloors, setAvailableFloors] = useState(null)
+  const [clickRejected, setClickRejected] = useState(false)
+
+  // Override: allows picking any location with any floor
+  const [overrideRestrictions, setOverrideRestrictions] = useState(false)
+
+  // Load regions and playing area on mount
+  useEffect(() => {
+    async function loadData() {
+      const [fetchedRegions, fetchedPlayingArea] = await Promise.all([
+        getRegions(),
+        getPlayingArea()
+      ])
+      setRegions(fetchedRegions)
+      setPlayingArea(fetchedPlayingArea)
+    }
+    loadData()
+  }, [])
 
   const handlePhotoSelect = (file) => {
     setPhoto(file)
@@ -20,25 +47,81 @@ function SubmissionForm() {
     setSubmitError('')
   }
 
-  const handleLocationSelect = (position) => {
-    setLocation(position)
+  const handleMapClick = useCallback((coords) => {
     setSubmitSuccess(false)
     setSubmitError('')
-  }
 
-  const handleFloorChange = (e) => {
-    setFloor(e.target.value)
+    // Check playing area restriction (skip if override is on)
+    if (!overrideRestrictions && !isPointInPlayingArea(coords, playingArea)) {
+      setClickRejected(true)
+      setTimeout(() => setClickRejected(false), 500)
+      return
+    }
+
+    setLocation(coords)
+    setClickRejected(false)
+
+    if (overrideRestrictions) {
+      // In override mode, always show all floors
+      setAvailableFloors(ALL_FLOORS)
+    } else {
+      // Determine available floors based on region (matching game behavior)
+      const floors = getFloorsForPoint(coords, regions)
+      setAvailableFloors(floors)
+
+      // Reset floor selection if current selection is not in available floors
+      if (floors === null || (floor && !floors.includes(floor))) {
+        setFloor(null)
+      }
+    }
+  }, [overrideRestrictions, playingArea, regions, floor])
+
+  const handleFloorSelect = useCallback((selectedFloor) => {
+    setFloor(selectedFloor)
     setSubmitSuccess(false)
     setSubmitError('')
-  }
+  }, [])
+
+  const handleOverrideChange = useCallback((e) => {
+    const checked = e.target.checked
+    setOverrideRestrictions(checked)
+
+    if (checked) {
+      // When enabling override, show all floors immediately if a location is selected
+      if (location) {
+        setAvailableFloors(ALL_FLOORS)
+      }
+    } else {
+      // When disabling override, re-evaluate floors based on regions
+      if (location) {
+        const inPlayingArea = isPointInPlayingArea(location, playingArea)
+        if (!inPlayingArea) {
+          // Location is outside playing area, clear it
+          setLocation(null)
+          setFloor(null)
+          setAvailableFloors(null)
+        } else {
+          const floors = getFloorsForPoint(location, regions)
+          setAvailableFloors(floors)
+          if (floors === null || (floor && !floors.includes(floor))) {
+            setFloor(null)
+          }
+        }
+      }
+    }
+  }, [location, playingArea, regions, floor])
 
   const resetForm = () => {
     setPhoto(null)
     setLocation(null)
-    setFloor('')
+    setFloor(null)
+    setAvailableFloors(null)
     // Don't reset submitSuccess here - it should persist to show the success message
     setSubmitError('')
   }
+
+  // Determine if floor selection should be shown
+  const isInRegion = availableFloors !== null && availableFloors.length > 0
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -52,8 +135,8 @@ function SubmissionForm() {
       setSubmitError('Please select a location on the map')
       return
     }
-    if (!floor || isNaN(parseInt(floor))) {
-      setSubmitError('Please enter a valid floor number')
+    if (isInRegion && floor === null) {
+      setSubmitError('Please select a floor')
       return
     }
 
@@ -69,7 +152,7 @@ function SubmissionForm() {
       await uploadBytes(storageRef, photo)
       const photoURL = await getDownloadURL(storageRef)
 
-      // Save submission to Firestore
+      // Save submission to Firestore (percentage-based coordinates matching game)
       await addDoc(collection(db, 'submissions'), {
         photoURL,
         photoName: photo.name,
@@ -77,7 +160,7 @@ function SubmissionForm() {
           x: location.x,
           y: location.y
         },
-        floor: parseInt(floor),
+        floor: floor || 1,
         status: 'pending', // pending, approved, denied
         createdAt: serverTimestamp(),
         reviewedAt: null
@@ -112,19 +195,49 @@ function SubmissionForm() {
       <form onSubmit={handleSubmit}>
         <PhotoUpload onPhotoSelect={handlePhotoSelect} selectedPhoto={photo} />
 
-        <MapSelector onLocationSelect={handleLocationSelect} selectedLocation={location} />
-
-        <div className="floor-input">
-          <h3>Floor Number</h3>
-          <input
-            type="number"
-            value={floor}
-            onChange={handleFloorChange}
-            placeholder="Enter floor number (e.g., 1, 2, 3)"
-            min="1"
-            max="3"
+        <div className="location-section">
+          <MapPicker
+            markerPosition={location}
+            onMapClick={handleMapClick}
+            clickRejected={clickRejected}
+            playingArea={overrideRestrictions ? null : playingArea}
           />
-          <p className="floor-hint">Floors 1-3 only</p>
+
+          <div className="override-control">
+            <label className="override-label">
+              <input
+                type="checkbox"
+                checked={overrideRestrictions}
+                onChange={handleOverrideChange}
+              />
+              <span>Allow any location and floor</span>
+            </label>
+            <p className="override-hint">
+              Bypasses playing area and region restrictions
+            </p>
+          </div>
+
+          {isInRegion && (
+            <FloorSelector
+              selectedFloor={floor}
+              onFloorSelect={handleFloorSelect}
+              floors={availableFloors}
+            />
+          )}
+
+          {/* Status indicators matching game style */}
+          <div className="location-status">
+            <div className={`status-item ${location ? 'complete' : ''}`}>
+              <span className="status-icon">{location ? '\u2713' : '\u25CB'}</span>
+              <span>Location selected</span>
+            </div>
+            {isInRegion && (
+              <div className={`status-item ${floor ? 'complete' : ''}`}>
+                <span className="status-icon">{floor ? '\u2713' : '\u25CB'}</span>
+                <span>Floor selected</span>
+              </div>
+            )}
+          </div>
         </div>
 
         <button

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.test.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.test.jsx
@@ -25,18 +25,53 @@ vi.mock('firebase/storage', () => ({
   getDownloadURL: (...args) => mockGetDownloadURL(...args)
 }));
 
+// Mock regionService
+const mockGetRegions = vi.fn();
+const mockGetPlayingArea = vi.fn();
+const mockGetFloorsForPoint = vi.fn();
+const mockIsPointInPlayingArea = vi.fn();
+
+vi.mock('../../services/regionService', () => ({
+  getRegions: (...args) => mockGetRegions(...args),
+  getPlayingArea: (...args) => mockGetPlayingArea(...args),
+  getFloorsForPoint: (...args) => mockGetFloorsForPoint(...args),
+  isPointInPlayingArea: (...args) => mockIsPointInPlayingArea(...args)
+}));
+
 // Mock child components
-vi.mock('./MapSelector', () => ({
-  default: ({ onLocationSelect, selectedLocation }) => (
-    <div data-testid="map-selector">
-      <button onClick={() => onLocationSelect({ x: 100, y: 200 })}>
-        Select Location
+vi.mock('../MapPicker/MapPicker', () => ({
+  default: ({ markerPosition, onMapClick, clickRejected, playingArea }) => (
+    <div data-testid="map-picker">
+      <button onClick={() => onMapClick({ x: 50, y: 50 })}>
+        Click Map
       </button>
-      {selectedLocation && (
-        <span data-testid="selected-location">
-          {selectedLocation.x}, {selectedLocation.y}
+      <button onClick={() => onMapClick({ x: 90, y: 90 })} data-testid="click-outside">
+        Click Outside
+      </button>
+      {markerPosition && (
+        <span data-testid="marker-position">
+          {markerPosition.x}, {markerPosition.y}
         </span>
       )}
+      {clickRejected && <span data-testid="click-rejected">Rejected</span>}
+      {playingArea && <span data-testid="has-playing-area">Playing Area Active</span>}
+    </div>
+  )
+}));
+
+vi.mock('../FloorSelector/FloorSelector', () => ({
+  default: ({ selectedFloor, onFloorSelect, floors }) => (
+    <div data-testid="floor-selector">
+      {floors.map((floor) => (
+        <button
+          key={floor}
+          data-testid={`floor-${floor}`}
+          onClick={() => onFloorSelect(floor)}
+          className={selectedFloor === floor ? 'selected' : ''}
+        >
+          Floor {floor}
+        </button>
+      ))}
     </div>
   )
 }));
@@ -61,6 +96,10 @@ describe('SubmissionForm', () => {
     mockUploadBytes.mockResolvedValue({});
     mockGetDownloadURL.mockResolvedValue('https://example.com/photo.jpg');
     mockAddDoc.mockResolvedValue({ id: 'test-doc-id' });
+    mockGetRegions.mockResolvedValue([]);
+    mockGetPlayingArea.mockResolvedValue(null);
+    mockGetFloorsForPoint.mockReturnValue(null);
+    mockIsPointInPlayingArea.mockReturnValue(true);
   });
 
   describe('initial render', () => {
@@ -74,15 +113,14 @@ describe('SubmissionForm', () => {
       expect(screen.getByTestId('photo-upload')).toBeInTheDocument();
     });
 
-    it('should render MapSelector component', () => {
+    it('should render MapPicker component', () => {
       render(<SubmissionForm />);
-      expect(screen.getByTestId('map-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('map-picker')).toBeInTheDocument();
     });
 
-    it('should render floor input', () => {
+    it('should render override checkbox', () => {
       render(<SubmissionForm />);
-      expect(screen.getByText('Floor Number')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)')).toBeInTheDocument();
+      expect(screen.getByText('Allow any location and floor')).toBeInTheDocument();
     });
 
     it('should render submit button', () => {
@@ -99,30 +137,108 @@ describe('SubmissionForm', () => {
       render(<SubmissionForm />);
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
+
+    it('should show location status indicator', () => {
+      render(<SubmissionForm />);
+      expect(screen.getByText('Location selected')).toBeInTheDocument();
+    });
+
+    it('should not show floor selector initially', () => {
+      render(<SubmissionForm />);
+      expect(screen.queryByTestId('floor-selector')).not.toBeInTheDocument();
+    });
   });
 
-  describe('floor input', () => {
-    it('should allow entering floor number', async () => {
+  describe('location picking', () => {
+    it('should place marker when clicking on map', async () => {
       const user = userEvent.setup();
       render(<SubmissionForm />);
 
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
-      expect(floorInput).toHaveValue(2);
+      expect(screen.getByTestId('marker-position')).toHaveTextContent('50, 50');
     });
 
-    it('should have min and max attributes', () => {
+    it('should show floor selector when location is in a region', async () => {
+      mockGetFloorsForPoint.mockReturnValue([1, 2, 3]);
+      const user = userEvent.setup();
       render(<SubmissionForm />);
 
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      expect(floorInput).toHaveAttribute('min', '1');
-      expect(floorInput).toHaveAttribute('max', '3');
+      await user.click(screen.getByText('Click Map'));
+
+      expect(screen.getByTestId('floor-selector')).toBeInTheDocument();
     });
 
-    it('should show floor hint', () => {
+    it('should not show floor selector when location is not in a region', async () => {
+      mockGetFloorsForPoint.mockReturnValue(null);
+      const user = userEvent.setup();
       render(<SubmissionForm />);
-      expect(screen.getByText('Floors 1-3 only')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Click Map'));
+
+      expect(screen.queryByTestId('floor-selector')).not.toBeInTheDocument();
+    });
+
+    it('should show floor status indicator when in a region', async () => {
+      mockGetFloorsForPoint.mockReturnValue([1, 2]);
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      await user.click(screen.getByText('Click Map'));
+
+      expect(screen.getByText('Floor selected')).toBeInTheDocument();
+    });
+  });
+
+  describe('override checkbox', () => {
+    it('should hide playing area overlay when override is checked', async () => {
+      mockGetPlayingArea.mockResolvedValue({ polygon: [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 100, y: 100 }] });
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      // Wait for playing area to load
+      await waitFor(() => {
+        expect(screen.getByTestId('has-playing-area')).toBeInTheDocument();
+      });
+
+      // Check the override checkbox
+      await user.click(screen.getByText('Allow any location and floor'));
+
+      // Playing area should be hidden
+      expect(screen.queryByTestId('has-playing-area')).not.toBeInTheDocument();
+    });
+
+    it('should show all floors when override is enabled and location is selected', async () => {
+      mockGetFloorsForPoint.mockReturnValue(null); // Not in a region normally
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      // Enable override
+      await user.click(screen.getByText('Allow any location and floor'));
+
+      // Click on map
+      await user.click(screen.getByText('Click Map'));
+
+      // Should show floor selector with all floors
+      expect(screen.getByTestId('floor-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('floor-1')).toBeInTheDocument();
+      expect(screen.getByTestId('floor-2')).toBeInTheDocument();
+      expect(screen.getByTestId('floor-3')).toBeInTheDocument();
+    });
+
+    it('should bypass playing area restriction when override is enabled', async () => {
+      mockIsPointInPlayingArea.mockReturnValue(false);
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      // Enable override
+      await user.click(screen.getByText('Allow any location and floor'));
+
+      // Click outside playing area
+      await user.click(screen.getByTestId('click-outside'));
+
+      // Marker should still be placed
+      expect(screen.getByTestId('marker-position')).toBeInTheDocument();
     });
   });
 
@@ -148,35 +264,24 @@ describe('SubmissionForm', () => {
       expect(screen.getByText('Please select a location on the map')).toBeInTheDocument();
     });
 
-    it('should show error when submitting without floor', async () => {
+    it('should show error when submitting without floor in a region', async () => {
+      mockGetFloorsForPoint.mockReturnValue([1, 2, 3]);
       const user = userEvent.setup();
       render(<SubmissionForm />);
 
       // Upload a photo
       await user.click(screen.getByText('Upload Photo'));
-      // Select location
-      await user.click(screen.getByText('Select Location'));
+      // Select location (in a region)
+      await user.click(screen.getByText('Click Map'));
 
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
 
-      expect(screen.getByText('Please enter a valid floor number')).toBeInTheDocument();
+      expect(screen.getByText('Please select a floor')).toBeInTheDocument();
     });
 
-    it('should show error for invalid floor number', async () => {
-      const user = userEvent.setup();
+    it('should not disable submit button initially (validation on submit)', () => {
       render(<SubmissionForm />);
-
-      // Upload a photo
-      await user.click(screen.getByText('Upload Photo'));
-      // Select location
-      await user.click(screen.getByText('Select Location'));
-      // Enter invalid floor (non-numeric handled as NaN)
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.clear(floorInput);
-
-      await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
-
-      expect(screen.getByText('Please enter a valid floor number')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Submit Photo' })).not.toBeDisabled();
     });
   });
 
@@ -189,11 +294,9 @@ describe('SubmissionForm', () => {
 
       render(<SubmissionForm />);
 
-      // Fill in all fields
+      // Fill in all fields (not in a region, so no floor needed)
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -215,9 +318,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -234,9 +335,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -258,9 +357,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -277,15 +374,31 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
 
       await waitFor(() => {
-        expect(floorInput).toHaveValue(null);
+        expect(screen.queryByTestId('marker-position')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should submit with floor when in a region', async () => {
+      mockGetFloorsForPoint.mockReturnValue([1, 2, 3]);
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      // Fill in all fields
+      await user.click(screen.getByText('Upload Photo'));
+      await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByTestId('floor-2'));
+
+      // Submit
+      await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
+
+      await waitFor(() => {
+        expect(mockAddDoc).toHaveBeenCalled();
       });
     });
 
@@ -295,9 +408,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -313,9 +424,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -335,9 +444,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -355,9 +462,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -375,9 +480,7 @@ describe('SubmissionForm', () => {
 
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
-      await user.click(screen.getByText('Select Location'));
-      const floorInput = screen.getByPlaceholderText('Enter floor number (e.g., 1, 2, 3)');
-      await user.type(floorInput, '2');
+      await user.click(screen.getByText('Click Map'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -388,7 +491,7 @@ describe('SubmissionForm', () => {
     });
   });
 
-  describe('error state behavior', () => {
+  describe('state behavior', () => {
     it('should update photo selected indicator after upload', async () => {
       const user = userEvent.setup();
       render(<SubmissionForm />);
@@ -403,18 +506,27 @@ describe('SubmissionForm', () => {
       expect(screen.getByTestId('selected-photo')).toHaveTextContent('test.jpg');
     });
 
-    it('should update location indicator after selection', async () => {
+    it('should update marker position after location selection', async () => {
       const user = userEvent.setup();
       render(<SubmissionForm />);
 
-      // Initially no location
-      expect(screen.queryByTestId('selected-location')).not.toBeInTheDocument();
+      // Initially no marker
+      expect(screen.queryByTestId('marker-position')).not.toBeInTheDocument();
 
       // Select location
-      await user.click(screen.getByText('Select Location'));
+      await user.click(screen.getByText('Click Map'));
 
       // Should show coordinates
-      expect(screen.getByTestId('selected-location')).toHaveTextContent('100, 200');
+      expect(screen.getByTestId('marker-position')).toHaveTextContent('50, 50');
+    });
+
+    it('should load regions and playing area on mount', async () => {
+      render(<SubmissionForm />);
+
+      await waitFor(() => {
+        expect(mockGetRegions).toHaveBeenCalled();
+        expect(mockGetPlayingArea).toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replaced the upload form's custom `MapSelector` (pixel coordinates) and manual floor `<input>` with the game's `MapPicker` (percentage-based coordinates) and `FloorSelector` components
- Location picking now uses the same playing area restrictions, region-based floor detection, and click rejection behavior as the game
- Added an **"Allow any location and floor"** override checkbox that bypasses playing area and region restrictions, showing all floors (1-3) for any clicked location

## Test plan
- [ ] Verify `MapPicker` renders in the upload form with the playing area overlay
- [ ] Click inside the playing area and confirm marker placement and floor selector appears when in a region
- [ ] Click outside the playing area and confirm the click is rejected
- [ ] Check the override checkbox and verify clicking anywhere places a marker with all floors available
- [ ] Uncheck override while a marker is outside the playing area and confirm it clears the selection
- [ ] Submit a photo with location + floor and verify it saves to Firestore with percentage-based coordinates
- [ ] Run `npx vitest run src/components/SubmissionApp/SubmissionForm.test.jsx` — all 34 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)