### PR TITLE
Replace Firebase Storage with Base64-in-Firestore for image uploads

### DIFF
--- a/react-vite-app/src/App.test.jsx
+++ b/react-vite-app/src/App.test.jsx
@@ -11,7 +11,6 @@ vi.mock('./services/imageService', () => ({
 // Mock Firebase
 vi.mock('./firebase', () => ({
   db: {},
-  storage: {},
   app: {}
 }));
 

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
-import { db, storage } from '../../firebase'
+import { db } from '../../firebase'
+import { compressImage } from '../../utils/compressImage'
 import MapSelector from './MapSelector'
 import PhotoUpload from './PhotoUpload'
 import './SubmissionForm.css'
@@ -61,17 +61,12 @@ function SubmissionForm() {
     setSubmitError('')
 
     try {
-      // Upload photo to Firebase Storage
-      const timestamp = Date.now()
-      const fileName = `submissions/${timestamp}_${photo.name}`
-      const storageRef = ref(storage, fileName)
+      // Compress image and convert to Base64 data URL
+      const photoDataUrl = await compressImage(photo)
 
-      await uploadBytes(storageRef, photo)
-      const photoURL = await getDownloadURL(storageRef)
-
-      // Save submission to Firestore
+      // Save submission with embedded image to Firestore
       await addDoc(collection(db, 'submissions'), {
-        photoURL,
+        photoURL: photoDataUrl,
         photoName: photo.name,
         location: {
           x: location.x,

--- a/react-vite-app/src/firebase.js
+++ b/react-vite-app/src/firebase.js
@@ -1,7 +1,6 @@
 // Firebase configuration and initialization
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyAP-WcJoYaym3OMJ4vx-oW5FQ7c1mtq7bo",
@@ -19,7 +18,4 @@ const app = initializeApp(firebaseConfig);
 // Initialize Firestore
 const db = getFirestore(app);
 
-// Initialize Storage
-const storage = getStorage(app);
-
-export { app, db, storage };
+export { app, db };

--- a/react-vite-app/src/utils/compressImage.js
+++ b/react-vite-app/src/utils/compressImage.js
@@ -1,0 +1,50 @@
+/**
+ * Compresses an image file using canvas and returns a Base64 data URL.
+ * Resizes to fit within maxWidth/maxHeight while maintaining aspect ratio,
+ * then compresses as JPEG at the given quality.
+ *
+ * @param {File} file - The image file to compress
+ * @param {Object} options
+ * @param {number} options.maxWidth - Max width in pixels (default 800)
+ * @param {number} options.maxHeight - Max height in pixels (default 800)
+ * @param {number} options.quality - JPEG quality 0-1 (default 0.7)
+ * @returns {Promise<string>} Base64 data URL of the compressed image
+ */
+export function compressImage(file, { maxWidth = 800, maxHeight = 800, quality = 0.7 } = {}) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = (event) => {
+      const img = new Image()
+
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+
+        let { width, height } = img
+
+        // Scale down to fit within max dimensions while keeping aspect ratio
+        if (width > maxWidth || height > maxHeight) {
+          const ratio = Math.min(maxWidth / width, maxHeight / height)
+          width = Math.round(width * ratio)
+          height = Math.round(height * ratio)
+        }
+
+        canvas.width = width
+        canvas.height = height
+
+        const ctx = canvas.getContext('2d')
+        ctx.drawImage(img, 0, 0, width, height)
+
+        // Convert to JPEG data URL
+        const dataUrl = canvas.toDataURL('image/jpeg', quality)
+        resolve(dataUrl)
+      }
+
+      img.onerror = () => reject(new Error('Failed to load image for compression'))
+      img.src = event.target.result
+    }
+
+    reader.onerror = () => reject(new Error('Failed to read image file'))
+    reader.readAsDataURL(file)
+  })
+}

--- a/submission-app/src/components/SubmissionForm.jsx
+++ b/submission-app/src/components/SubmissionForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
-import { db, storage } from '../firebase'
+import { db } from '../firebase'
+import { compressImage } from '../utils/compressImage'
 import MapSelector from './MapSelector'
 import PhotoUpload from './PhotoUpload'
 import './SubmissionForm.css'
@@ -61,17 +61,12 @@ function SubmissionForm() {
     setSubmitError('')
 
     try {
-      // Upload photo to Firebase Storage
-      const timestamp = Date.now()
-      const fileName = `submissions/${timestamp}_${photo.name}`
-      const storageRef = ref(storage, fileName)
+      // Compress image and convert to Base64 data URL
+      const photoDataUrl = await compressImage(photo)
 
-      await uploadBytes(storageRef, photo)
-      const photoURL = await getDownloadURL(storageRef)
-
-      // Save submission to Firestore
+      // Save submission with embedded image to Firestore
       await addDoc(collection(db, 'submissions'), {
-        photoURL,
+        photoURL: photoDataUrl,
         photoName: photo.name,
         location: {
           x: location.x,

--- a/submission-app/src/firebase.js
+++ b/submission-app/src/firebase.js
@@ -1,7 +1,6 @@
 // Firebase configuration and initialization
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyAP-WcJoYaym3OMJ4vx-oW5FQ7c1mtq7bo",
@@ -19,7 +18,4 @@ const app = initializeApp(firebaseConfig);
 // Initialize Firestore
 const db = getFirestore(app);
 
-// Initialize Storage
-const storage = getStorage(app);
-
-export { app, db, storage };
+export { app, db };

--- a/submission-app/src/utils/compressImage.js
+++ b/submission-app/src/utils/compressImage.js
@@ -1,0 +1,50 @@
+/**
+ * Compresses an image file using canvas and returns a Base64 data URL.
+ * Resizes to fit within maxWidth/maxHeight while maintaining aspect ratio,
+ * then compresses as JPEG at the given quality.
+ *
+ * @param {File} file - The image file to compress
+ * @param {Object} options
+ * @param {number} options.maxWidth - Max width in pixels (default 800)
+ * @param {number} options.maxHeight - Max height in pixels (default 800)
+ * @param {number} options.quality - JPEG quality 0-1 (default 0.7)
+ * @returns {Promise<string>} Base64 data URL of the compressed image
+ */
+export function compressImage(file, { maxWidth = 800, maxHeight = 800, quality = 0.7 } = {}) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onload = (event) => {
+      const img = new Image()
+
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+
+        let { width, height } = img
+
+        // Scale down to fit within max dimensions while keeping aspect ratio
+        if (width > maxWidth || height > maxHeight) {
+          const ratio = Math.min(maxWidth / width, maxHeight / height)
+          width = Math.round(width * ratio)
+          height = Math.round(height * ratio)
+        }
+
+        canvas.width = width
+        canvas.height = height
+
+        const ctx = canvas.getContext('2d')
+        ctx.drawImage(img, 0, 0, width, height)
+
+        // Convert to JPEG data URL
+        const dataUrl = canvas.toDataURL('image/jpeg', quality)
+        resolve(dataUrl)
+      }
+
+      img.onerror = () => reject(new Error('Failed to load image for compression'))
+      img.src = event.target.result
+    }
+
+    reader.onerror = () => reject(new Error('Failed to read image file'))
+    reader.readAsDataURL(file)
+  })
+}


### PR DESCRIPTION
## Summary
- **Removed Firebase Storage dependency** — Storage requires the Blaze (paid) plan, which caused CORS errors since the bucket couldn't be provisioned on the free Spark tier
- **Added client-side image compression** — Images are resized (max 800×800px) and compressed to JPEG at 70% quality using a canvas-based utility
- **Store images as Base64 data URLs in Firestore** — The compressed image is embedded directly in the Firestore `submissions` document, which is available on the free tier
- **Updated tests** — All SubmissionForm tests updated to mock `compressImage` instead of Firebase Storage (26/26 passing)

## Test plan
- [ ] Verify photo submission works end-to-end on the deployed site (upload photo → compresses → saves to Firestore)
- [ ] Verify AdminReview displays submitted photos correctly (Base64 data URLs render in `<img>` tags seamlessly)
- [ ] Verify image quality is acceptable after compression
- [ ] Run `npx vitest run src/components/SubmissionApp/SubmissionForm.test.jsx` — all 26 tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)