### PR TITLE
Fix submission page not clearing photo preview after submit

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/PhotoUpload.jsx
+++ b/react-vite-app/src/components/SubmissionApp/PhotoUpload.jsx
@@ -1,10 +1,20 @@
-import { useState, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import './PhotoUpload.css'
 
 function PhotoUpload({ onPhotoSelect, selectedPhoto }) {
   const [preview, setPreview] = useState(selectedPhoto ? URL.createObjectURL(selectedPhoto) : null)
   const [dragActive, setDragActive] = useState(false)
   const inputRef = useRef(null)
+
+  // Sync preview state when selectedPhoto is cleared by parent (e.g., after form submission)
+  useEffect(() => {
+    if (!selectedPhoto) {
+      setPreview(null)
+      if (inputRef.current) {
+        inputRef.current.value = ''
+      }
+    }
+  }, [selectedPhoto])
 
   const handleFileChange = (e) => {
     const file = e.target.files[0]

--- a/react-vite-app/src/components/SubmissionApp/PhotoUpload.test.jsx
+++ b/react-vite-app/src/components/SubmissionApp/PhotoUpload.test.jsx
@@ -285,6 +285,43 @@ describe('PhotoUpload', () => {
     });
   });
 
+  describe('clearing preview when selectedPhoto prop becomes null', () => {
+    it('should clear preview when selectedPhoto changes from a file to null', () => {
+      const selectedPhoto = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+      const { rerender } = render(
+        <PhotoUpload onPhotoSelect={mockOnPhotoSelect} selectedPhoto={selectedPhoto} />
+      );
+
+      // Preview should be visible
+      expect(screen.getByAltText('Preview')).toBeInTheDocument();
+
+      // Parent resets selectedPhoto to null (e.g., after form submission)
+      rerender(<PhotoUpload onPhotoSelect={mockOnPhotoSelect} selectedPhoto={null} />);
+
+      // Preview should be cleared and drop zone should reappear
+      expect(screen.queryByAltText('Preview')).not.toBeInTheDocument();
+      expect(screen.getByText('Click to upload or drag and drop')).toBeInTheDocument();
+    });
+
+    it('should clear file input value when selectedPhoto becomes null', () => {
+      const selectedPhoto = new File(['test'], 'test.jpg', { type: 'image/jpeg' });
+      const { rerender } = render(
+        <PhotoUpload onPhotoSelect={mockOnPhotoSelect} selectedPhoto={selectedPhoto} />
+      );
+
+      const input = document.querySelector('input[type="file"]');
+      Object.defineProperty(input, 'value', {
+        writable: true,
+        value: 'C:\\fakepath\\test.jpg'
+      });
+
+      // Parent resets selectedPhoto to null
+      rerender(<PhotoUpload onPhotoSelect={mockOnPhotoSelect} selectedPhoto={null} />);
+
+      expect(input.value).toBe('');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle drop with no files', () => {
       render(<PhotoUpload onPhotoSelect={mockOnPhotoSelect} selectedPhoto={null} />);

--- a/submission-app/src/components/PhotoUpload.jsx
+++ b/submission-app/src/components/PhotoUpload.jsx
@@ -1,10 +1,20 @@
-import { useState, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import './PhotoUpload.css'
 
 function PhotoUpload({ onPhotoSelect, selectedPhoto }) {
   const [preview, setPreview] = useState(selectedPhoto ? URL.createObjectURL(selectedPhoto) : null)
   const [dragActive, setDragActive] = useState(false)
   const inputRef = useRef(null)
+
+  // Sync preview state when selectedPhoto is cleared by parent (e.g., after form submission)
+  useEffect(() => {
+    if (!selectedPhoto) {
+      setPreview(null)
+      if (inputRef.current) {
+        inputRef.current.value = ''
+      }
+    }
+  }, [selectedPhoto])
 
   const handleFileChange = (e) => {
     const file = e.target.files[0]


### PR DESCRIPTION
## Summary
- Fixed a bug where the `PhotoUpload` component's image preview remained visible after a successful photo submission
- Added a `useEffect` hook to both `react-vite-app` and `submission-app` `PhotoUpload` components that syncs the internal `preview` state when the parent clears `selectedPhoto` to `null`
- Added 2 new tests verifying the preview clears and file input resets when `selectedPhoto` prop becomes `null`

## Test plan
- [x] All 620 tests pass (618 existing + 2 new)
- [ ] Manually submit a photo and verify the preview image, map marker, and form fields are all cleared after submission
- [ ] Verify the drop zone reappears after submission so a new photo can be uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)