### PR TITLE
Fix photos with no floor defaulting to Floor 1

### DIFF
--- a/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
+++ b/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
@@ -117,12 +117,14 @@ function FinalResultsScreen({ rounds, onPlayAgain, onBackToTitle }) {
                       <span className="round-stat-label">Location</span>
                       <span className="round-stat-value">{round.locationScore.toLocaleString()}</span>
                     </div>
-                    <div className="round-stat">
-                      <span className="round-stat-label">Floor</span>
-                      <span className={`round-stat-value ${round.floorCorrect ? 'correct' : 'penalty'}`}>
-                        {round.floorCorrect ? '✓' : '-20%'}
-                      </span>
-                    </div>
+                    {round.floorCorrect !== null && (
+                      <div className="round-stat">
+                        <span className="round-stat-label">Floor</span>
+                        <span className={`round-stat-value ${round.floorCorrect ? 'correct' : 'penalty'}`}>
+                          {round.floorCorrect ? '✓' : '-20%'}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
                 <div className="round-score">

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -67,10 +67,11 @@ function ResultScreen({
 
   const distance = calculateDistance(guessLocation, actualLocation);
   const locationScore = calculateScore(distance);
-  const floorCorrect = guessFloor === actualFloor;
-  // Multiply by 0.8 for incorrect floor
-  const totalScore = floorCorrect ? locationScore : Math.round(locationScore * 0.8);
-  const floorPenalty = floorCorrect ? 0 : Math.round(locationScore * 0.2);
+  const hasFloorScoring = guessFloor !== null && actualFloor !== null;
+  const floorCorrect = hasFloorScoring ? guessFloor === actualFloor : null;
+  // Multiply by 0.8 for incorrect floor (only when both floors are set)
+  const totalScore = (hasFloorScoring && !floorCorrect) ? Math.round(locationScore * 0.8) : locationScore;
+  const floorPenalty = (hasFloorScoring && !floorCorrect) ? Math.round(locationScore * 0.2) : 0;
 
   // Animation sequence
   useEffect(() => {
@@ -253,17 +254,19 @@ function ResultScreen({
               <span className="stat-value">{formatDistance(distance)}</span>
             </div>
 
-            <div className="stat-row">
-              <span className="stat-icon">🏢</span>
-              <span className="stat-label">Floor</span>
-              <span className={`stat-value ${guessFloor === actualFloor ? 'correct' : 'incorrect'}`}>
-                {guessFloor === actualFloor ? (
-                  <>Correct! (Floor {actualFloor})</>
-                ) : (
-                  <>You: {guessFloor} | Actual: {actualFloor}</>
-                )}
-              </span>
-            </div>
+            {hasFloorScoring && (
+              <div className="stat-row">
+                <span className="stat-icon">🏢</span>
+                <span className="stat-label">Floor</span>
+                <span className={`stat-value ${floorCorrect ? 'correct' : 'incorrect'}`}>
+                  {floorCorrect ? (
+                    <>Correct! (Floor {actualFloor})</>
+                  ) : (
+                    <>You: {guessFloor} | Actual: {actualFloor}</>
+                  )}
+                </span>
+              </div>
+            )}
 
             <div className="score-breakdown">
               <div className="breakdown-row">

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.test.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.test.jsx
@@ -197,6 +197,20 @@ describe('ResultScreen', () => {
 
       expect(screen.queryByText('Wrong Floor (-20%)')).not.toBeInTheDocument();
     });
+
+    it('should not show floor section when actualFloor is null', () => {
+      render(<ResultScreen {...defaultProps} guessFloor={null} actualFloor={null} />);
+
+      expect(screen.queryByText('Floor')).not.toBeInTheDocument();
+      expect(screen.queryByText('Wrong Floor (-20%)')).not.toBeInTheDocument();
+    });
+
+    it('should not show floor section when guessFloor is null', () => {
+      render(<ResultScreen {...defaultProps} guessFloor={null} actualFloor={2} />);
+
+      expect(screen.queryByText(/Correct!/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Wrong Floor (-20%)')).not.toBeInTheDocument();
+    });
   });
 
   describe('next round button', () => {

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
@@ -155,7 +155,7 @@ function SubmissionForm() {
           x: location.x,
           y: location.y
         },
-        floor: floor || 1,
+        floor: floor ?? null,
         status: 'pending', // pending, approved, denied
         createdAt: serverTimestamp(),
         reviewedAt: null

--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -191,17 +191,17 @@ export function useGameState() {
 
     // Get correct location and floor from the image data
     const actualLocation = currentImage.correctLocation || { x: 50, y: 50 };
-    const actualFloor = currentImage.correctFloor || 1;
+    const actualFloor = currentImage.correctFloor ?? null;
 
     // Calculate scores
     const distance = calculateDistance(guessLocation, actualLocation);
     const locationScore = calculateLocationScore(distance);
 
-    // Floor scoring only applies when in a region
+    // Floor scoring only applies when in a region AND the photo has a floor set
     let floorCorrect = null;
     let totalScore = locationScore;
 
-    if (isInRegion && guessFloor !== null) {
+    if (isInRegion && guessFloor !== null && actualFloor !== null) {
       floorCorrect = guessFloor === actualFloor;
       // Multiply by 0.8 for incorrect floor instead of bonus system
       totalScore = floorCorrect ? locationScore : Math.round(locationScore * 0.8);

--- a/react-vite-app/src/hooks/useGameState.test.js
+++ b/react-vite-app/src/hooks/useGameState.test.js
@@ -726,7 +726,7 @@ describe('useGameState', () => {
       expect(result.current.currentResult.locationScore).toBe(5000);
     });
 
-    it('should use default floor if correctFloor is missing', async () => {
+    it('should use null floor if correctFloor is missing', async () => {
       // Mock an image without correctFloor
       const imageWithoutFloor = {
         id: 'test-no-floor',
@@ -747,16 +747,16 @@ describe('useGameState', () => {
       });
 
       act(() => {
-        result.current.selectFloor(1); // Guess floor 1, which should be the default
+        result.current.selectFloor(1); // Guess floor 1
       });
 
       act(() => {
         result.current.submitGuess();
       });
 
-      // Should use default floor 1
-      expect(result.current.currentResult.actualFloor).toBe(1);
-      expect(result.current.currentResult.floorCorrect).toBe(true);
+      // Should use null floor - no floor scoring when photo has no floor
+      expect(result.current.currentResult.actualFloor).toBeNull();
+      expect(result.current.currentResult.floorCorrect).toBeNull();
     });
 
     it('should decrease score with distance', async () => {


### PR DESCRIPTION
## Summary
- Photos submitted without a floor selection were stored as `floor: 1` due to a `floor || 1` fallback in the submission form, making it impossible for players to get the floor correct during gameplay
- Changed all floor handling to preserve `null` when no floor is selected: submission stores `null`, game scoring skips floor comparison, and UI hides the floor section entirely
- Added tests verifying that null floors are handled correctly in both game scoring and result display

## Test plan
- [x] All 676 tests pass (including 2 new tests for null floor handling)
- [ ] Submit a photo without selecting a floor → verify it's stored with `floor: null` in Firestore
- [ ] Play a round with a no-floor photo → verify no floor penalty is applied and floor section is hidden on result screen
- [ ] Play a round with a floor-assigned photo → verify floor scoring still works correctly
- [ ] Check final results screen shows floor stats only for rounds that had floor scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)