### PR TITLE
Enable full property editing for images in admin review screen

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/AdminReview.css
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.css
@@ -339,3 +339,168 @@
 .modal-actions .reset-button {
   padding: 12px 30px;
 }
+
+/* Modal Details Header with Edit button */
+.modal-details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.modal-details-header h3 {
+  margin-bottom: 0;
+}
+
+.edit-button {
+  padding: 8px 20px;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.edit-button:hover {
+  background-color: #2980b9;
+}
+
+/* Edit Form Styles */
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.edit-field > label {
+  font-weight: bold;
+  font-size: 14px;
+  color: #333;
+}
+
+.edit-field input[type="text"],
+.edit-field select {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.edit-field input[type="text"]:focus,
+.edit-field select:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+/* Coordinate inputs inline */
+.coordinate-inputs {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.coordinate-inputs label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: bold;
+  font-size: 14px;
+  color: #333;
+}
+
+.coordinate-inputs input[type="number"] {
+  width: 80px;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.coordinate-inputs input[type="number"]:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+/* Photo replacement section */
+.edit-photo-section {
+  position: relative;
+}
+
+.replace-photo-controls {
+  padding: 10px 20px;
+  background-color: #f8f9fa;
+  border-top: 1px solid #eee;
+}
+
+/* Edit error message */
+.edit-error {
+  background-color: #fde8e8;
+  color: #e74c3c;
+  padding: 10px 14px;
+  border-radius: 4px;
+  font-size: 14px;
+  border: 1px solid #f5c6cb;
+}
+
+/* Save / Cancel buttons */
+.edit-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.save-button {
+  flex: 1;
+  padding: 12px;
+  background-color: #27ae60;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.save-button:hover:not(:disabled) {
+  background-color: #219a52;
+}
+
+.save-button:disabled {
+  background-color: #bdc3c7;
+  cursor: not-allowed;
+}
+
+.cancel-edit-button {
+  flex: 1;
+  padding: 12px;
+  background-color: #95a5a6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.cancel-edit-button:hover:not(:disabled) {
+  background-color: #7f8c8d;
+}
+
+.cancel-edit-button:disabled {
+  cursor: not-allowed;
+}

--- a/react-vite-app/src/components/SubmissionApp/AdminReview.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.jsx
@@ -2,6 +2,10 @@ import { useState, useEffect } from 'react'
 import { collection, query, orderBy, onSnapshot, doc, updateDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../../firebase'
 import { getAllImages, getAllSampleImages } from '../../services/imageService'
+import MapPicker from '../MapPicker/MapPicker'
+import FloorSelector from '../FloorSelector/FloorSelector'
+import PhotoUpload from './PhotoUpload'
+import { compressImage } from '../../utils/compressImage'
 import './AdminReview.css'
 
 function AdminReview({ onBack }) {
@@ -12,6 +16,13 @@ function AdminReview({ onBack }) {
   const [filter, setFilter] = useState('all') // pending, approved, denied, all
   const [sourceFilter, setSourceFilter] = useState('all') // all, submissions, images, testing
   const [selectedSubmission, setSelectedSubmission] = useState(null)
+
+  // Edit mode state
+  const [isEditing, setIsEditing] = useState(false)
+  const [editForm, setEditForm] = useState({})
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState('')
+  const [newPhoto, setNewPhoto] = useState(null)
 
   // Fetch submissions from Firestore (real-time)
   useEffect(() => {
@@ -96,6 +107,96 @@ function AdminReview({ onBack }) {
     }
   }
 
+  // Edit mode handlers
+  const handleStartEdit = () => {
+    setEditForm({
+      description: selectedSubmission.description || '',
+      photoName: selectedSubmission.photoName || '',
+      location: selectedSubmission.location ? { ...selectedSubmission.location } : { x: 0, y: 0 },
+      floor: selectedSubmission.floor,
+      status: selectedSubmission.status,
+    })
+    setNewPhoto(null)
+    setSaveError('')
+    setIsEditing(true)
+  }
+
+  const handleCancelEdit = () => {
+    setIsEditing(false)
+    setEditForm({})
+    setNewPhoto(null)
+    setSaveError('')
+  }
+
+  const handleCloseModal = () => {
+    handleCancelEdit()
+    setSelectedSubmission(null)
+  }
+
+  const handleSaveEdit = async () => {
+    // Validation
+    if (!editForm.location || editForm.location.x === undefined || editForm.location.y === undefined) {
+      setSaveError('Location is required')
+      return
+    }
+    if (editForm.floor === null || editForm.floor === undefined) {
+      setSaveError('Floor is required')
+      return
+    }
+
+    setIsSaving(true)
+    setSaveError('')
+
+    try {
+      let photoURL = selectedSubmission.photoURL
+
+      // If new photo was uploaded, compress it
+      if (newPhoto) {
+        photoURL = await compressImage(newPhoto)
+      }
+
+      if (selectedSubmission._source === 'submission') {
+        await updateDoc(doc(db, 'submissions', selectedSubmission.id), {
+          description: editForm.description,
+          photoName: editForm.photoName,
+          location: editForm.location,
+          floor: editForm.floor,
+          status: editForm.status,
+          photoURL: photoURL,
+        })
+        // Real-time listener will auto-update submissions state
+      } else if (selectedSubmission._source === 'image') {
+        await updateDoc(doc(db, 'images', selectedSubmission.id), {
+          description: editForm.description,
+          correctLocation: editForm.location,
+          correctFloor: editForm.floor,
+          url: photoURL,
+        })
+        // Manually update firestoreImages state (no real-time listener)
+        setFirestoreImages(prev => prev.map(img =>
+          img.id === selectedSubmission.id
+            ? {
+                ...img,
+                description: editForm.description,
+                photoName: editForm.description || selectedSubmission.id,
+                location: editForm.location,
+                floor: editForm.floor,
+                photoURL: photoURL,
+              }
+            : img
+        ))
+      }
+
+      setIsEditing(false)
+      setSelectedSubmission(null)
+    } catch (error) {
+      console.error('Error saving edit:', error)
+      setSaveError('Failed to save changes. Please try again.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   // Combine all image sources
   const allItems = [...submissions, ...firestoreImages, ...sampleImages]
 
@@ -139,6 +240,8 @@ function AdminReview({ onBack }) {
     const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
     return date.toLocaleString()
   }
+
+  const isEditable = selectedSubmission && selectedSubmission._source !== 'testing'
 
   if (loading) {
     return (
@@ -312,64 +415,206 @@ function AdminReview({ onBack }) {
       )}
 
       {selectedSubmission && (
-        <div className="modal-overlay" onClick={() => setSelectedSubmission(null)}>
+        <div className="modal-overlay" onClick={handleCloseModal}>
           <div className="modal-content" onClick={e => e.stopPropagation()}>
-            <button className="modal-close" onClick={() => setSelectedSubmission(null)}>
+            <button className="modal-close" onClick={handleCloseModal}>
               ×
             </button>
-            <img src={selectedSubmission.photoURL} alt="Full size" className="modal-image" />
+
+            {/* Image display / replacement */}
+            {isEditing ? (
+              <div className="edit-photo-section">
+                <img
+                  src={newPhoto ? URL.createObjectURL(newPhoto) : selectedSubmission.photoURL}
+                  alt="Current"
+                  className="modal-image"
+                />
+                <div className="replace-photo-controls">
+                  <PhotoUpload onPhotoSelect={setNewPhoto} selectedPhoto={newPhoto} />
+                </div>
+              </div>
+            ) : (
+              <img src={selectedSubmission.photoURL} alt="Full size" className="modal-image" />
+            )}
+
             <div className="modal-details">
-              <h3>Image Details</h3>
-              <p><strong>Source:</strong> <span className={getSourceBadgeClass(selectedSubmission._source)}>{getSourceLabel(selectedSubmission._source)}</span></p>
-              <p><strong>Status:</strong> <span className={getStatusBadgeClass(selectedSubmission.status)}>{selectedSubmission.status}</span></p>
-              {selectedSubmission.description && (
-                <p><strong>Description:</strong> {selectedSubmission.description}</p>
-              )}
-              <p><strong>Location:</strong> X: {selectedSubmission.location?.x}, Y: {selectedSubmission.location?.y}</p>
-              <p><strong>Floor:</strong> {selectedSubmission.floor}</p>
-              <p><strong>File Name:</strong> {selectedSubmission.photoName}</p>
-              {selectedSubmission.createdAt && (
-                <p><strong>Submitted:</strong> {formatDate(selectedSubmission.createdAt)}</p>
-              )}
-              {selectedSubmission.reviewedAt && (
-                <p><strong>Reviewed:</strong> {formatDate(selectedSubmission.reviewedAt)}</p>
-              )}
+              {isEditing ? (
+                /* Edit mode form */
+                <div className="edit-form">
+                  <div className="modal-details-header">
+                    <h3>Edit Image</h3>
+                  </div>
 
-              {selectedSubmission._source === 'submission' && selectedSubmission.status === 'pending' && (
-                <div className="modal-actions">
-                  <button
-                    className="approve-button"
-                    onClick={() => {
-                      handleApprove(selectedSubmission.id)
-                      setSelectedSubmission(null)
-                    }}
-                  >
-                    Approve
-                  </button>
-                  <button
-                    className="deny-button"
-                    onClick={() => {
-                      handleDeny(selectedSubmission.id)
-                      setSelectedSubmission(null)
-                    }}
-                  >
-                    Deny
-                  </button>
-                </div>
-              )}
+                  {saveError && <div className="edit-error">{saveError}</div>}
 
-              {selectedSubmission.status !== 'pending' && (
-                <div className="modal-actions">
-                  <button
-                    className="reset-button"
-                    onClick={() => {
-                      handleResetToPending(selectedSubmission.id)
-                      setSelectedSubmission(null)
-                    }}
-                  >
-                    Reset to Pending
-                  </button>
+                  {/* Description */}
+                  <div className="edit-field">
+                    <label htmlFor="edit-description">Description</label>
+                    <input
+                      id="edit-description"
+                      type="text"
+                      value={editForm.description}
+                      onChange={e => setEditForm(prev => ({ ...prev, description: e.target.value }))}
+                    />
+                  </div>
+
+                  {/* Photo Name (submissions only) */}
+                  {selectedSubmission._source === 'submission' && (
+                    <div className="edit-field">
+                      <label htmlFor="edit-photoname">File Name</label>
+                      <input
+                        id="edit-photoname"
+                        type="text"
+                        value={editForm.photoName}
+                        onChange={e => setEditForm(prev => ({ ...prev, photoName: e.target.value }))}
+                      />
+                    </div>
+                  )}
+
+                  {/* Status (submissions only) */}
+                  {selectedSubmission._source === 'submission' && (
+                    <div className="edit-field">
+                      <label htmlFor="edit-status">Status</label>
+                      <select
+                        id="edit-status"
+                        value={editForm.status}
+                        onChange={e => setEditForm(prev => ({ ...prev, status: e.target.value }))}
+                      >
+                        <option value="pending">Pending</option>
+                        <option value="approved">Approved</option>
+                        <option value="denied">Denied</option>
+                      </select>
+                    </div>
+                  )}
+
+                  {/* Location via MapPicker */}
+                  <div className="edit-field">
+                    <label>Location</label>
+                    <MapPicker
+                      markerPosition={editForm.location}
+                      onMapClick={(coords) => setEditForm(prev => ({ ...prev, location: coords }))}
+                    />
+                    <div className="coordinate-inputs">
+                      <label>
+                        X:
+                        <input
+                          type="number"
+                          min="0"
+                          max="100"
+                          step="0.1"
+                          value={editForm.location?.x ?? ''}
+                          onChange={e => setEditForm(prev => ({
+                            ...prev,
+                            location: { ...prev.location, x: parseFloat(e.target.value) || 0 }
+                          }))}
+                        />
+                      </label>
+                      <label>
+                        Y:
+                        <input
+                          type="number"
+                          min="0"
+                          max="100"
+                          step="0.1"
+                          value={editForm.location?.y ?? ''}
+                          onChange={e => setEditForm(prev => ({
+                            ...prev,
+                            location: { ...prev.location, y: parseFloat(e.target.value) || 0 }
+                          }))}
+                        />
+                      </label>
+                    </div>
+                  </div>
+
+                  {/* Floor via FloorSelector */}
+                  <div className="edit-field">
+                    <FloorSelector
+                      selectedFloor={editForm.floor}
+                      onFloorSelect={(f) => setEditForm(prev => ({ ...prev, floor: f }))}
+                    />
+                  </div>
+
+                  {/* Save / Cancel buttons */}
+                  <div className="edit-actions">
+                    <button
+                      className="save-button"
+                      onClick={handleSaveEdit}
+                      disabled={isSaving}
+                    >
+                      {isSaving ? 'Saving...' : 'Save Changes'}
+                    </button>
+                    <button
+                      className="cancel-edit-button"
+                      onClick={handleCancelEdit}
+                      disabled={isSaving}
+                    >
+                      Cancel
+                    </button>
+                  </div>
                 </div>
+              ) : (
+                /* Read-only view mode */
+                <>
+                  <div className="modal-details-header">
+                    <h3>Image Details</h3>
+                    {isEditable && (
+                      <button className="edit-button" onClick={handleStartEdit}>
+                        Edit
+                      </button>
+                    )}
+                  </div>
+                  <p><strong>Source:</strong> <span className={getSourceBadgeClass(selectedSubmission._source)}>{getSourceLabel(selectedSubmission._source)}</span></p>
+                  <p><strong>Status:</strong> <span className={getStatusBadgeClass(selectedSubmission.status)}>{selectedSubmission.status}</span></p>
+                  {selectedSubmission.description && (
+                    <p><strong>Description:</strong> {selectedSubmission.description}</p>
+                  )}
+                  <p><strong>Location:</strong> X: {selectedSubmission.location?.x}, Y: {selectedSubmission.location?.y}</p>
+                  <p><strong>Floor:</strong> {selectedSubmission.floor}</p>
+                  <p><strong>File Name:</strong> {selectedSubmission.photoName}</p>
+                  {selectedSubmission.createdAt && (
+                    <p><strong>Submitted:</strong> {formatDate(selectedSubmission.createdAt)}</p>
+                  )}
+                  {selectedSubmission.reviewedAt && (
+                    <p><strong>Reviewed:</strong> {formatDate(selectedSubmission.reviewedAt)}</p>
+                  )}
+
+                  {selectedSubmission._source === 'submission' && selectedSubmission.status === 'pending' && (
+                    <div className="modal-actions">
+                      <button
+                        className="approve-button"
+                        onClick={() => {
+                          handleApprove(selectedSubmission.id)
+                          setSelectedSubmission(null)
+                        }}
+                      >
+                        Approve
+                      </button>
+                      <button
+                        className="deny-button"
+                        onClick={() => {
+                          handleDeny(selectedSubmission.id)
+                          setSelectedSubmission(null)
+                        }}
+                      >
+                        Deny
+                      </button>
+                    </div>
+                  )}
+
+                  {selectedSubmission.status !== 'pending' && (
+                    <div className="modal-actions">
+                      <button
+                        className="reset-button"
+                        onClick={() => {
+                          handleResetToPending(selectedSubmission.id)
+                          setSelectedSubmission(null)
+                        }}
+                      >
+                        Reset to Pending
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Added an **edit mode toggle** in the admin review detail modal, enabling admins to edit all properties of any submission or game image
- Editable properties: **description**, **location** (MapPicker + manual X/Y coordinates), **floor** (FloorSelector), **photo** (PhotoUpload with compression), **file name** (submissions only), and **status** (submissions only)
- Testing/sample images remain **read-only** (no Edit button shown)
- Proper **field name mapping** on save: submissions use `photoURL`/`location`/`floor`, game images use `url`/`correctLocation`/`correctFloor`
- Game image local state is manually updated after save (no real-time listener); submissions auto-update via existing `onSnapshot`

## Test plan
- [x] All 80 AdminReview tests pass (28 new edit mode tests added)
- [x] Production build succeeds
- [ ] Open review screen → click "View Full Details" on a submission → click "Edit" → modify fields → save → verify Firestore update
- [ ] Repeat for a Game Image → verify field mapping (url, correctLocation, correctFloor)
- [ ] Verify testing/sample images do NOT show Edit button
- [ ] Test photo replacement with compress
- [ ] Test validation errors (missing floor)
- [ ] Test save failure error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)