### PR TITLE
Add ability to view and edit any user property in account management

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/AccountManagement.css
+++ b/react-vite-app/src/components/SubmissionApp/AccountManagement.css
@@ -150,6 +150,38 @@
   background-color: #c0392b;
 }
 
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.edit-user-button {
+  padding: 8px 16px;
+  background-color: #f39c12;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  transition: background-color 0.2s;
+}
+
+.edit-user-button:hover {
+  background-color: #d68910;
+}
+
+.uid-cell {
+  font-family: monospace;
+  font-size: 12px;
+  color: #999;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .action-locked {
   color: #8e44ad;
   font-size: 13px;

--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.css
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.css
@@ -1,0 +1,212 @@
+/* Overlay — matches AdminReview modal pattern */
+.user-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+/* Content card */
+.user-modal-content {
+  background-color: white;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 30px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+/* Close button */
+.user-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #999;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.user-modal-close:hover {
+  color: #333;
+  background-color: #f0f0f0;
+}
+
+/* Title */
+.user-modal-title {
+  font-size: 20px;
+  color: #2c3e50;
+  margin: 0 0 20px 0;
+}
+
+/* Error — matches AccountManagement .account-error */
+.user-modal-error {
+  background-color: #fdecea;
+  color: #c0392b;
+  padding: 12px 16px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  border: 1px solid #f5c6cb;
+}
+
+/* Form layout */
+.user-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Field rows */
+.user-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Labels — match table header style */
+.user-modal-label {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #666;
+}
+
+/* Inputs */
+.user-modal-input {
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #333;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.user-modal-input:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
+}
+
+.user-modal-input:disabled {
+  opacity: 0.6;
+  background-color: #f8f9fa;
+  cursor: not-allowed;
+}
+
+/* Read-only values */
+.user-modal-value {
+  font-size: 14px;
+  color: #333;
+  padding: 4px 0;
+}
+
+.user-modal-uid {
+  font-family: monospace;
+  font-size: 12px;
+  color: #666;
+  word-break: break-all;
+}
+
+.user-modal-locked {
+  color: #8e44ad;
+  font-weight: 600;
+  font-style: italic;
+}
+
+/* Checkbox label */
+.user-modal-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.user-modal-checkbox-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+/* Action buttons */
+.user-modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.user-modal-save {
+  flex: 1;
+  padding: 12px;
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+.user-modal-save:hover:not(:disabled) {
+  background-color: #2980b9;
+}
+
+.user-modal-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.user-modal-cancel {
+  flex: 1;
+  padding: 12px;
+  background-color: #ecf0f1;
+  color: #333;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.user-modal-cancel:hover:not(:disabled) {
+  background-color: #d5dbdb;
+}
+
+.user-modal-cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .user-modal-content {
+    padding: 20px;
+    margin: 10px;
+  }
+
+  .user-modal-actions {
+    flex-direction: column;
+  }
+}

--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
@@ -1,0 +1,171 @@
+import { useState } from 'react'
+import { isHardcodedAdmin } from '../../services/userService'
+import './UserEditModal.css'
+
+function UserEditModal({ user, onSave, onClose, isSaving }) {
+  const [formData, setFormData] = useState({
+    username: user.username || '',
+    email: user.email || '',
+    isAdmin: user.isAdmin || false,
+  })
+  const [error, setError] = useState(null)
+
+  const hardcoded = isHardcodedAdmin(user.id)
+
+  // Identify extra fields beyond the standard set
+  const standardFields = ['uid', 'email', 'username', 'isAdmin', 'createdAt']
+  const extraFields = Object.keys(user).filter(
+    key => !standardFields.includes(key) && key !== 'id'
+  )
+
+  const handleChange = (field, value) => {
+    setFormData(prev => ({ ...prev, [field]: value }))
+    setError(null)
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+
+    // Build updates object with only changed fields
+    const updates = {}
+    if (formData.username !== (user.username || '')) {
+      updates.username = formData.username
+    }
+    if (formData.email !== (user.email || '')) {
+      updates.email = formData.email
+    }
+    if (formData.isAdmin !== (user.isAdmin || false)) {
+      updates.isAdmin = formData.isAdmin
+    }
+
+    // Nothing changed — just close
+    if (Object.keys(updates).length === 0) {
+      onClose()
+      return
+    }
+
+    try {
+      await onSave(user.id, updates)
+    } catch (err) {
+      setError(err.message || 'Failed to update user.')
+    }
+  }
+
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'N/A'
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return (
+    <div className="user-modal-overlay" onClick={onClose}>
+      <div className="user-modal-content" onClick={e => e.stopPropagation()}>
+        <button className="user-modal-close" onClick={onClose}>&times;</button>
+
+        <h3 className="user-modal-title">Edit User</h3>
+
+        {error && <div className="user-modal-error">{error}</div>}
+
+        <form onSubmit={handleSubmit} className="user-modal-form">
+          {/* Read-only: UID */}
+          <div className="user-modal-field">
+            <label className="user-modal-label">User ID</label>
+            <span className="user-modal-value user-modal-uid">{user.id}</span>
+          </div>
+
+          {/* Editable: Username */}
+          <div className="user-modal-field">
+            <label className="user-modal-label" htmlFor="edit-username">Username</label>
+            <input
+              id="edit-username"
+              type="text"
+              className="user-modal-input"
+              value={formData.username}
+              onChange={(e) => handleChange('username', e.target.value)}
+              disabled={isSaving}
+            />
+          </div>
+
+          {/* Editable: Email */}
+          <div className="user-modal-field">
+            <label className="user-modal-label" htmlFor="edit-email">Email</label>
+            <input
+              id="edit-email"
+              type="email"
+              className="user-modal-input"
+              value={formData.email}
+              onChange={(e) => handleChange('email', e.target.value)}
+              disabled={isSaving}
+            />
+          </div>
+
+          {/* Editable: Admin toggle (unless hardcoded) */}
+          <div className="user-modal-field">
+            <label className="user-modal-label">Admin Status</label>
+            {hardcoded ? (
+              <span className="user-modal-value user-modal-locked">
+                Always Admin (Permanent)
+              </span>
+            ) : (
+              <label className="user-modal-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={formData.isAdmin}
+                  onChange={(e) => handleChange('isAdmin', e.target.checked)}
+                  disabled={isSaving}
+                />
+                <span>{formData.isAdmin ? 'Admin' : 'Not Admin'}</span>
+              </label>
+            )}
+          </div>
+
+          {/* Read-only: Created At */}
+          <div className="user-modal-field">
+            <label className="user-modal-label">Created</label>
+            <span className="user-modal-value">{formatDate(user.createdAt)}</span>
+          </div>
+
+          {/* Any extra/dynamic fields — displayed read-only */}
+          {extraFields.map(field => (
+            <div className="user-modal-field" key={field}>
+              <label className="user-modal-label">{field}</label>
+              <span className="user-modal-value">
+                {typeof user[field] === 'object'
+                  ? JSON.stringify(user[field])
+                  : String(user[field])}
+              </span>
+            </div>
+          ))}
+
+          {/* Actions */}
+          <div className="user-modal-actions">
+            <button
+              type="submit"
+              className="user-modal-save"
+              disabled={isSaving}
+            >
+              {isSaving ? 'Saving...' : 'Save Changes'}
+            </button>
+            <button
+              type="button"
+              className="user-modal-cancel"
+              onClick={onClose}
+              disabled={isSaving}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default UserEditModal


### PR DESCRIPTION
## Summary
- Added a modal-based user editor to the admin Account Management page with an "Edit" button on each user row
- Admins can now view all user properties and edit username, email, and admin status, with system fields (UID, createdAt) shown read-only
- Added `updateUserProfile` service function with validation (username uniqueness/length, hardcoded admin protection, system field guards)
- Added a UID column to the user table and auto-displays any extra/dynamic user properties in the edit modal

## Test plan
- [ ] Navigate to admin Account Management tab and verify the table shows the new UID column and "Edit" button per row
- [ ] Click "Edit" on a user and verify the modal opens with all properties pre-filled
- [ ] Modify username and click "Save Changes" — verify the table updates
- [ ] Try saving a duplicate or too-short username — verify validation error appears in the modal
- [ ] Verify hardcoded admin row shows locked "Always Admin (Permanent)" in the modal
- [ ] Verify "Cancel" and overlay click close the modal without saving
- [ ] Verify existing "Make Admin" / "Revoke Admin" buttons still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)