### PR TITLE
Redo scoring with GeoGuessr-style formula, 5000 pts within 10ft

### DIFF
--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -16,12 +16,10 @@ function calculateDistance(guess, actual) {
  * Format distance as a readable string
  */
 function formatDistance(distance) {
-  // Convert percentage distance to approximate "units" for display
-  // In a real campus, this might be meters or feet
-  const units = Math.round(distance * 2); // Arbitrary scaling
-  if (units < 5) return 'Perfect!';
-  if (units < 20) return `${units} ft away`;
-  return `${units} ft away`;
+  // Convert percentage distance to feet (1 percentage unit = 2 feet)
+  const feet = Math.round(distance * 2);
+  if (feet <= 10) return 'Perfect!';
+  return `${feet} ft away`;
 }
 
 function ResultScreen({

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.test.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.test.jsx
@@ -10,6 +10,8 @@ describe('ResultScreen', () => {
     actualLocation: { x: 50, y: 50 },
     actualFloor: 2,
     imageUrl: 'https://example.com/image.jpg',
+    locationScore: 5000,
+    totalScore: 5000,
     roundNumber: 1,
     totalRounds: 5,
     onNextRound: vi.fn(),
@@ -271,20 +273,20 @@ describe('ResultScreen', () => {
       expect(screen.getAllByText('Perfect!').length).toBeGreaterThan(0);
     });
 
-    it('should show distance in feet for moderate distance (5-20 units)', () => {
-      // Distance that gives units between 5 and 20 after * 2
-      // sqrt((dx)^2 + (dy)^2) = 5 => dx=3, dy=4 gives distance=5
-      // 5 * 2 = 10 units, which is >= 5 and < 20
+    it('should show distance in feet for moderate distance beyond 10 ft', () => {
+      // sqrt((60-50)^2 + (50-50)^2) = 10, * 2 = 20 ft
       render(
         <ResultScreen
           {...defaultProps}
-          guessLocation={{ x: 53, y: 54 }}
+          guessLocation={{ x: 60, y: 50 }}
           actualLocation={{ x: 50, y: 50 }}
+          locationScore={4933}
+          totalScore={4933}
         />
       );
 
-      // Distance is 5, * 2 = 10 ft
-      expect(screen.getByText('10 ft away')).toBeInTheDocument();
+      // Distance is 10, * 2 = 20 ft
+      expect(screen.getByText('20 ft away')).toBeInTheDocument();
     });
 
     it('should show distance in feet for larger distance (>= 20 units)', () => {
@@ -293,6 +295,8 @@ describe('ResultScreen', () => {
           {...defaultProps}
           guessLocation={{ x: 50, y: 50 }}
           actualLocation={{ x: 60, y: 60 }}
+          locationScore={4431}
+          totalScore={4431}
         />
       );
 
@@ -300,9 +304,8 @@ describe('ResultScreen', () => {
       expect(screen.getByText(/\d+ ft away/)).toBeInTheDocument();
     });
 
-    it('should show "Perfect!" for very small distance (units < 5)', () => {
-      // Distance that gives units < 5 after * 2
-      // 2 / 2 = 1 distance
+    it('should show "Perfect!" for distance within 10 ft', () => {
+      // Distance is 1, * 2 = 2 ft which is <= 10 ft
       render(
         <ResultScreen
           {...defaultProps}
@@ -311,7 +314,6 @@ describe('ResultScreen', () => {
         />
       );
 
-      // Distance is 1, * 2 = 2 units < 5, so should show "Perfect!"
       expect(screen.getAllByText('Perfect!').length).toBeGreaterThan(0);
     });
   });

--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -17,11 +17,20 @@ function calculateDistance(guess, actual) {
 
 /**
  * Calculate location score based on distance (0-5000 points)
+ * Uses the GeoGuessr scoring formula: 5000 * e^(-10 * (d/D)^2)
+ * At 10 ft (distance=5 in map coords) or closer, the player gets 5000.
+ * Score decays to 0 at the maximum possible distance (map diagonal).
  */
 function calculateLocationScore(distance) {
   const maxScore = 5000;
-  const decayRate = 0.05;
-  const score = Math.round(maxScore * Math.exp(-decayRate * distance));
+  const perfectRadius = 5; // 10 ft = 5 percentage units (distance * 2 = feet)
+  const maxDistance = Math.sqrt(100 * 100 + 100 * 100) - perfectRadius; // ~136.42
+
+  if (distance <= perfectRadius) return maxScore;
+
+  const effectiveDistance = distance - perfectRadius;
+  const ratio = effectiveDistance / maxDistance;
+  const score = Math.round(maxScore * Math.exp(-10 * ratio * ratio));
   return Math.max(0, Math.min(maxScore, score));
 }
 


### PR DESCRIPTION
## Summary
- Replaced the old exponential decay scoring (`5000 * e^(-0.05 * d)`) with a GeoGuessr-style formula: `5000 * e^(-10 * (d/D)²)`
- Players now receive a perfect **5,000 points** when guessing within **10 ft** of the target
- Score smoothly decays to **0** at the maximum possible map distance (~283 ft / map diagonal)
- Updated `formatDistance` to show "Perfect!" for any guess within 10 ft

## Test plan
- [x] All 36 scoring unit tests pass (`scoring.test.js`)
- [x] All 39 ResultScreen component tests pass (`ResultScreen.test.jsx`)
- [ ] Manual playtest to verify scoring feels right in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)