### PR TITLE
Add difficulty selection screen and difficulty field to images

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -4,6 +4,7 @@ import { useGameState } from './hooks/useGameState';
 import LoginScreen from './components/LoginScreen/LoginScreen';
 import ProfileScreen from './components/ProfileScreen/ProfileScreen';
 import TitleScreen from './components/TitleScreen/TitleScreen';
+import DifficultySelect from './components/DifficultySelect/DifficultySelect';
 import GameScreen from './components/GameScreen/GameScreen';
 import ResultScreen from './components/ResultScreen/ResultScreen';
 import FinalResultsScreen from './components/FinalResultsScreen/FinalResultsScreen';
@@ -31,6 +32,8 @@ function App() {
     playingArea,
     timeRemaining,
     roundTimeSeconds,
+    difficulty,
+    setScreen,
     startGame,
     placeMarker,
     selectFloor,
@@ -80,13 +83,43 @@ function App() {
     );
   }
 
+  /**
+   * Handle the "Play" button on the title screen → go to difficulty select
+   */
+  const handlePlay = () => {
+    setScreen('difficultySelect');
+  };
+
+  /**
+   * Handle starting the game from difficulty select
+   */
+  const handleStartFromDifficulty = (selectedDifficulty, mode) => {
+    // mode is 'singleplayer' (multiplayer is disabled)
+    startGame(selectedDifficulty);
+  };
+
+  /**
+   * Go back from difficulty select to the title screen
+   */
+  const handleBackToTitle = () => {
+    setScreen('title');
+  };
+
   return (
     <div className="app">
       {screen === 'title' && (
         <TitleScreen
-          onStartGame={startGame}
+          onPlay={handlePlay}
           onOpenSubmission={() => setShowSubmissionApp(true)}
           onOpenProfile={() => setShowProfile(true)}
+          isLoading={isLoading}
+        />
+      )}
+
+      {screen === 'difficultySelect' && (
+        <DifficultySelect
+          onStart={handleStartFromDifficulty}
+          onBack={handleBackToTitle}
           isLoading={isLoading}
         />
       )}
@@ -134,7 +167,7 @@ function App() {
       {screen === 'finalResults' && (
         <FinalResultsScreen
           rounds={roundResults}
-          onPlayAgain={startGame}
+          onPlayAgain={() => setScreen('difficultySelect')}
           onBackToTitle={resetGame}
         />
       )}

--- a/react-vite-app/src/App.test.jsx
+++ b/react-vite-app/src/App.test.jsx
@@ -59,6 +59,26 @@ const mockImage = {
   description: 'Test image'
 };
 
+/**
+ * Helper: navigate from title screen through difficulty select to the game screen.
+ * Clicks Play on title -> selects Easy difficulty -> clicks Play on difficulty select.
+ */
+const navigateToGame = async (user) => {
+  // Click Play on title screen to go to difficulty select
+  await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+  // Wait for difficulty select screen
+  await waitFor(() => {
+    expect(screen.getByText('Choose Difficulty')).toBeInTheDocument();
+  });
+
+  // Select Easy difficulty
+  await user.click(screen.getByText('Easy'));
+
+  // Click Play on difficulty select to start the game
+  await user.click(screen.getByRole('button', { name: /^play$/i }));
+};
+
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -76,10 +96,10 @@ describe('App', () => {
       expect(screen.getByText('HW Geoguessr')).toBeInTheDocument();
     });
 
-    it('should render the start game button', () => {
+    it('should render the play button', () => {
       render(<App />);
 
-      expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^play$/i })).toBeInTheDocument();
     });
 
     it('should render the submit photo button', () => {
@@ -95,13 +115,45 @@ describe('App', () => {
     });
   });
 
-  describe('game flow', () => {
-    it('should transition to game screen when start game is clicked', async () => {
+  describe('difficulty select flow', () => {
+    it('should show difficulty select screen when play is clicked', async () => {
       const user = userEvent.setup();
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Choose Difficulty')).toBeInTheDocument();
+      });
+    });
+
+    it('should return to title screen when back is clicked from difficulty select', async () => {
+      const user = userEvent.setup();
+
+      render(<App />);
+
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Choose Difficulty')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('← Back'));
+
+      await waitFor(() => {
+        expect(screen.getByText('HW Geoguessr')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('game flow', () => {
+    it('should transition to game screen when difficulty is selected and play is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(<App />);
+
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -113,7 +165,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(getRandomImage).toHaveBeenCalled();
@@ -125,7 +177,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('1 / 5')).toBeInTheDocument();
@@ -137,7 +189,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByAltText(/mystery location/i)).toHaveAttribute('src', mockImage.url);
@@ -151,7 +203,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /guess/i })).toBeDisabled();
@@ -163,7 +215,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -199,7 +251,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -240,7 +292,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -262,7 +314,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText(/failed to load image/i)).toBeInTheDocument();
@@ -276,7 +328,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /back to home/i })).toBeInTheDocument();
@@ -290,7 +342,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /back to home/i })).toBeInTheDocument();
@@ -347,7 +399,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Location selected').parentElement).not.toHaveClass('complete');
@@ -359,7 +411,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -388,7 +440,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -423,7 +475,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -508,7 +560,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       // Play through 5 rounds
       for (let round = 1; round <= 5; round++) {
@@ -529,7 +581,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       // Complete 5 rounds
       for (let round = 1; round <= 5; round++) {
@@ -549,7 +601,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       // Complete 5 rounds
       for (let round = 1; round <= 5; round++) {
@@ -572,7 +624,7 @@ describe('App', () => {
   });
 
   describe('loading states', () => {
-    it('should show loading state when starting game', async () => {
+    it('should show loading state when starting game from difficulty select', async () => {
       // Make getRandomImage take some time
       getRandomImage.mockImplementation(
         () => new Promise(resolve => setTimeout(() => resolve(mockImage), 100))
@@ -582,9 +634,20 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      // Navigate to difficulty select
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
 
-      // Button should show loading
+      await waitFor(() => {
+        expect(screen.getByText('Choose Difficulty')).toBeInTheDocument();
+      });
+
+      // Select difficulty
+      await user.click(screen.getByText('Easy'));
+
+      // Click Play on difficulty select to start the game
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+      // Button should show loading on difficulty select screen
       expect(screen.getByRole('button', { name: /loading/i })).toBeDisabled();
 
       await waitFor(() => {
@@ -603,12 +666,22 @@ describe('App', () => {
 
       render(<App />);
 
-      // Start the game - this will set screen to 'game' and isLoading to true
-      act(() => {
-        user.click(screen.getByRole('button', { name: /start game/i }));
+      // Navigate to difficulty select
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Choose Difficulty')).toBeInTheDocument();
       });
 
-      // Wait for the loading button to show (title screen loading)
+      // Select difficulty and click Play
+      await user.click(screen.getByText('Easy'));
+
+      // Start the game - this will call startGame which sets isLoading to true
+      act(() => {
+        user.click(screen.getByRole('button', { name: /^play$/i }));
+      });
+
+      // Wait for the loading button to show (difficulty select loading)
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /loading/i })).toBeInTheDocument();
       });
@@ -631,7 +704,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();
@@ -661,7 +734,7 @@ describe('App', () => {
 
       render(<App />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await navigateToGame(user);
 
       await waitFor(() => {
         expect(screen.getByText('Make Your Guess')).toBeInTheDocument();

--- a/react-vite-app/src/components/DifficultySelect/DifficultySelect.css
+++ b/react-vite-app/src/components/DifficultySelect/DifficultySelect.css
@@ -1,0 +1,318 @@
+.difficulty-screen {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.difficulty-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.difficulty-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 20% 80%, rgba(108, 181, 45, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(108, 181, 45, 0.08) 0%, transparent 40%);
+}
+
+.difficulty-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(0deg, rgba(12, 12, 15, 0.8) 0%, transparent 50%),
+    linear-gradient(180deg, rgba(12, 12, 15, 0.4) 0%, transparent 30%);
+}
+
+.difficulty-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem;
+  max-width: 700px;
+  width: 100%;
+}
+
+.difficulty-back-button {
+  position: absolute;
+  top: 0;
+  left: 2rem;
+  padding: 8px 18px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.difficulty-back-button:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text-primary);
+}
+
+/* Headings */
+.difficulty-heading {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+  text-shadow: 0 0 30px rgba(108, 181, 45, 0.2);
+}
+
+.difficulty-subheading {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+
+.mode-heading {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 2.5rem;
+  margin-bottom: 1.2rem;
+  text-shadow: 0 0 30px rgba(108, 181, 45, 0.2);
+}
+
+/* Difficulty Cards */
+.difficulty-options {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.difficulty-card {
+  flex: 1;
+  max-width: 200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 2px solid var(--border-color);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  color: var(--text-primary);
+}
+
+.difficulty-card:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--border-light);
+  transform: translateY(-3px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+}
+
+.difficulty-card.selected {
+  border-color: var(--accent-green);
+  background: rgba(108, 181, 45, 0.12);
+  box-shadow: 0 0 20px rgba(108, 181, 45, 0.2);
+}
+
+.difficulty-card-icon {
+  font-size: 2rem;
+}
+
+.difficulty-card-label {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.difficulty-card-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.3;
+}
+
+/* Mode Cards */
+.mode-options {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  justify-content: center;
+}
+
+.mode-card-wrapper {
+  position: relative;
+  flex: 1;
+  max-width: 200px;
+}
+
+.mode-card {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  border-radius: 14px;
+  border: 2px solid var(--border-color);
+  transition: all 0.25s ease;
+  color: var(--text-primary);
+  cursor: default;
+}
+
+.mode-singleplayer {
+  flex: 1;
+  max-width: 200px;
+  background: rgba(108, 181, 45, 0.12);
+  border-color: var(--accent-green);
+  box-shadow: 0 0 20px rgba(108, 181, 45, 0.2);
+  opacity: 1 !important;
+}
+
+.mode-multiplayer {
+  background: rgba(255, 255, 255, 0.03);
+  opacity: 0.4 !important;
+  cursor: not-allowed;
+}
+
+.mode-card-icon {
+  font-size: 2rem;
+}
+
+.mode-card-label {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+/* Coming Soon tooltip */
+.coming-soon-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+  border: 1px solid var(--border-color);
+  pointer-events: none;
+  animation: tooltipFadeIn 0.15s ease;
+}
+
+.coming-soon-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--border-color);
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+/* Play Button */
+.play-button {
+  margin-top: 2.5rem;
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  font-size: 1.3rem;
+  font-weight: 600;
+  padding: 1rem 4rem;
+  border-radius: 50px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.play-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.play-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.play-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .difficulty-heading,
+  .mode-heading {
+    font-size: 1.7rem;
+  }
+
+  .difficulty-options,
+  .mode-options {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .difficulty-card,
+  .mode-singleplayer,
+  .mode-card-wrapper {
+    max-width: 280px;
+    width: 100%;
+  }
+
+  .play-button {
+    font-size: 1.1rem;
+    padding: 0.9rem 3rem;
+  }
+
+  .difficulty-back-button {
+    position: static;
+    margin-bottom: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .difficulty-heading,
+  .mode-heading {
+    font-size: 1.4rem;
+  }
+
+  .difficulty-content {
+    padding: 1.5rem 1rem;
+  }
+}

--- a/react-vite-app/src/components/DifficultySelect/DifficultySelect.jsx
+++ b/react-vite-app/src/components/DifficultySelect/DifficultySelect.jsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import './DifficultySelect.css';
+
+const DIFFICULTIES = [
+  {
+    id: 'easy',
+    label: 'Easy',
+    icon: '🟢',
+    description: 'Familiar spots around campus',
+  },
+  {
+    id: 'medium',
+    label: 'Medium',
+    icon: '🟡',
+    description: 'Trickier angles and locations',
+  },
+  {
+    id: 'hard',
+    label: 'Hard',
+    icon: '🔴',
+    description: 'Only true experts will know these',
+  },
+];
+
+function DifficultySelect({ onStart, onBack, isLoading }) {
+  const [selectedDifficulty, setSelectedDifficulty] = useState(null);
+  const [multiplayerHovered, setMultiplayerHovered] = useState(false);
+
+  const handleStart = () => {
+    if (selectedDifficulty) {
+      onStart(selectedDifficulty, 'singleplayer');
+    }
+  };
+
+  return (
+    <div className="difficulty-screen">
+      <div className="difficulty-background">
+        <div className="difficulty-overlay"></div>
+      </div>
+
+      <div className="difficulty-content">
+        <button className="difficulty-back-button" onClick={onBack}>
+          ← Back
+        </button>
+
+        <h2 className="difficulty-heading">Choose Difficulty</h2>
+        <p className="difficulty-subheading">Select how challenging you want the game to be</p>
+
+        <div className="difficulty-options">
+          {DIFFICULTIES.map((diff) => (
+            <button
+              key={diff.id}
+              className={`difficulty-card ${selectedDifficulty === diff.id ? 'selected' : ''}`}
+              onClick={() => setSelectedDifficulty(diff.id)}
+            >
+              <span className="difficulty-card-icon">{diff.icon}</span>
+              <span className="difficulty-card-label">{diff.label}</span>
+              <span className="difficulty-card-desc">{diff.description}</span>
+            </button>
+          ))}
+        </div>
+
+        <h2 className="mode-heading">Game Mode</h2>
+
+        <div className="mode-options">
+          <button
+            className="mode-card mode-singleplayer selected"
+            disabled
+          >
+            <span className="mode-card-icon">👤</span>
+            <span className="mode-card-label">Singleplayer</span>
+          </button>
+
+          <div
+            className="mode-card-wrapper"
+            onMouseEnter={() => setMultiplayerHovered(true)}
+            onMouseLeave={() => setMultiplayerHovered(false)}
+          >
+            <button
+              className="mode-card mode-multiplayer disabled"
+              disabled
+            >
+              <span className="mode-card-icon">👥</span>
+              <span className="mode-card-label">Multiplayer</span>
+            </button>
+            {multiplayerHovered && (
+              <span className="coming-soon-tooltip">Coming Soon!</span>
+            )}
+          </div>
+        </div>
+
+        <button
+          className="play-button"
+          onClick={handleStart}
+          disabled={!selectedDifficulty || isLoading}
+        >
+          {isLoading ? (
+            <>
+              <span className="button-spinner"></span>
+              Loading...
+            </>
+          ) : (
+            'Play'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default DifficultySelect;

--- a/react-vite-app/src/components/SubmissionApp/AdminReview.css
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.css
@@ -504,3 +504,32 @@
 .cancel-edit-button:disabled {
   cursor: not-allowed;
 }
+
+/* Difficulty badges */
+.difficulty-badge {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: capitalize;
+}
+
+.difficulty-badge-easy {
+  background-color: rgba(39, 174, 96, 0.15);
+  color: #27ae60;
+}
+
+.difficulty-badge-medium {
+  background-color: rgba(243, 156, 18, 0.15);
+  color: #f39c12;
+}
+
+.difficulty-badge-hard {
+  background-color: rgba(231, 76, 60, 0.15);
+  color: #e74c3c;
+}
+
+.difficulty-badge-none {
+  background-color: rgba(149, 165, 166, 0.15);
+  color: #95a5a6;
+}

--- a/react-vite-app/src/components/SubmissionApp/AdminReview.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.jsx
@@ -8,6 +8,8 @@ import PhotoUpload from './PhotoUpload'
 import { compressImage } from '../../utils/compressImage'
 import './AdminReview.css'
 
+const DIFFICULTY_OPTIONS = ['easy', 'medium', 'hard']
+
 function AdminReview({ onBack }) {
   const [submissions, setSubmissions] = useState([])
   const [firestoreImages, setFirestoreImages] = useState([])
@@ -53,6 +55,7 @@ function AdminReview({ onBack }) {
         photoURL: img.url,
         location: img.correctLocation,
         floor: img.correctFloor,
+        difficulty: img.difficulty || null,
         photoName: img.description || img.id,
         status: 'approved',
         _source: 'image',
@@ -114,6 +117,7 @@ function AdminReview({ onBack }) {
       photoName: selectedSubmission.photoName || '',
       location: selectedSubmission.location ? { ...selectedSubmission.location } : { x: 0, y: 0 },
       floor: selectedSubmission.floor,
+      difficulty: selectedSubmission.difficulty || null,
       status: selectedSubmission.status,
     })
     setNewPhoto(null)
@@ -161,6 +165,7 @@ function AdminReview({ onBack }) {
           photoName: editForm.photoName,
           location: editForm.location,
           floor: editForm.floor,
+          difficulty: editForm.difficulty || null,
           status: editForm.status,
           photoURL: photoURL,
         })
@@ -170,6 +175,7 @@ function AdminReview({ onBack }) {
           description: editForm.description,
           correctLocation: editForm.location,
           correctFloor: editForm.floor,
+          difficulty: editForm.difficulty || null,
           url: photoURL,
         })
         // Manually update firestoreImages state (no real-time listener)
@@ -181,6 +187,7 @@ function AdminReview({ onBack }) {
                 photoName: editForm.description || selectedSubmission.id,
                 location: editForm.location,
                 floor: editForm.floor,
+                difficulty: editForm.difficulty || null,
                 photoURL: photoURL,
               }
             : img
@@ -361,6 +368,12 @@ function AdminReview({ onBack }) {
                   <strong>Floor:</strong>
                   <span>{submission.floor}</span>
                 </div>
+                <div className="detail-row">
+                  <strong>Difficulty:</strong>
+                  <span className={`difficulty-badge difficulty-badge-${submission.difficulty || 'none'}`}>
+                    {submission.difficulty ? submission.difficulty.charAt(0).toUpperCase() + submission.difficulty.slice(1) : 'Not set'}
+                  </span>
+                </div>
                 {submission.createdAt && (
                   <div className="detail-row">
                     <strong>Submitted:</strong>
@@ -534,6 +547,21 @@ function AdminReview({ onBack }) {
                     />
                   </div>
 
+                  {/* Difficulty */}
+                  <div className="edit-field">
+                    <label htmlFor="edit-difficulty">Difficulty</label>
+                    <select
+                      id="edit-difficulty"
+                      value={editForm.difficulty || ''}
+                      onChange={e => setEditForm(prev => ({ ...prev, difficulty: e.target.value || null }))}
+                    >
+                      <option value="">Not set</option>
+                      {DIFFICULTY_OPTIONS.map(d => (
+                        <option key={d} value={d}>{d.charAt(0).toUpperCase() + d.slice(1)}</option>
+                      ))}
+                    </select>
+                  </div>
+
                   {/* Save / Cancel buttons */}
                   <div className="edit-actions">
                     <button
@@ -570,6 +598,12 @@ function AdminReview({ onBack }) {
                   )}
                   <p><strong>Location:</strong> X: {selectedSubmission.location?.x}, Y: {selectedSubmission.location?.y}</p>
                   <p><strong>Floor:</strong> {selectedSubmission.floor}</p>
+                  <p>
+                    <strong>Difficulty:</strong>{' '}
+                    <span className={`difficulty-badge difficulty-badge-${selectedSubmission.difficulty || 'none'}`}>
+                      {selectedSubmission.difficulty ? selectedSubmission.difficulty.charAt(0).toUpperCase() + selectedSubmission.difficulty.slice(1) : 'Not set'}
+                    </span>
+                  </p>
                   <p><strong>File Name:</strong> {selectedSubmission.photoName}</p>
                   {selectedSubmission.createdAt && (
                     <p><strong>Submitted:</strong> {formatDate(selectedSubmission.createdAt)}</p>

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.css
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.css
@@ -90,6 +90,66 @@
   text-align: center;
 }
 
+/* Difficulty selector */
+.difficulty-selector {
+  padding: 0 0.25rem;
+}
+
+.difficulty-selector-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary, #333);
+  margin-bottom: 0.5rem;
+}
+
+.difficulty-selector-icon {
+  font-size: 1.1rem;
+}
+
+.difficulty-selector-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.difficulty-selector-button {
+  flex: 1;
+  padding: 10px 16px;
+  border: 2px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary, #333);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.difficulty-selector-button:hover {
+  border-color: var(--border-light, #aaa);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.difficulty-selector-button.selected.difficulty-easy {
+  border-color: #27ae60;
+  background: rgba(39, 174, 96, 0.15);
+  color: #27ae60;
+}
+
+.difficulty-selector-button.selected.difficulty-medium {
+  border-color: #f39c12;
+  background: rgba(243, 156, 18, 0.15);
+  color: #f39c12;
+}
+
+.difficulty-selector-button.selected.difficulty-hard {
+  border-color: #e74c3c;
+  background: rgba(231, 76, 60, 0.15);
+  color: #e74c3c;
+}
+
 .submit-button {
   width: 100%;
   padding: 15px 30px;

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.jsx
@@ -11,10 +11,13 @@ import './SubmissionForm.css'
 // All possible floors when override is enabled
 const ALL_FLOORS = [1, 2, 3]
 
+const DIFFICULTY_OPTIONS = ['easy', 'medium', 'hard']
+
 function SubmissionForm() {
   const [photo, setPhoto] = useState(null)
   const [location, setLocation] = useState(null)
   const [floor, setFloor] = useState(null)
+  const [difficulty, setDifficulty] = useState(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitSuccess, setSubmitSuccess] = useState(false)
   const [submitError, setSubmitError] = useState('')
@@ -115,6 +118,7 @@ function SubmissionForm() {
     setPhoto(null)
     setLocation(null)
     setFloor(null)
+    setDifficulty(null)
     setAvailableFloors(null)
     // Don't reset submitSuccess here - it should persist to show the success message
     setSubmitError('')
@@ -139,6 +143,10 @@ function SubmissionForm() {
       setSubmitError('Please select a floor')
       return
     }
+    if (!difficulty) {
+      setSubmitError('Please select a difficulty')
+      return
+    }
 
     setIsSubmitting(true)
     setSubmitError('')
@@ -156,6 +164,7 @@ function SubmissionForm() {
           y: location.y
         },
         floor: floor ?? null,
+        difficulty: difficulty,
         status: 'pending', // pending, approved, denied
         createdAt: serverTimestamp(),
         reviewedAt: null
@@ -220,6 +229,26 @@ function SubmissionForm() {
             />
           )}
 
+          {/* Difficulty selector */}
+          <div className="difficulty-selector">
+            <div className="difficulty-selector-header">
+              <span className="difficulty-selector-icon">🎯</span>
+              <span>Select Difficulty</span>
+            </div>
+            <div className="difficulty-selector-buttons">
+              {DIFFICULTY_OPTIONS.map((diff) => (
+                <button
+                  key={diff}
+                  type="button"
+                  className={`difficulty-selector-button ${difficulty === diff ? 'selected' : ''} difficulty-${diff}`}
+                  onClick={() => { setDifficulty(diff); setSubmitError(''); setSubmitSuccess(false); }}
+                >
+                  {diff.charAt(0).toUpperCase() + diff.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+
           {/* Status indicators matching game style */}
           <div className="location-status">
             <div className={`status-item ${location ? 'complete' : ''}`}>
@@ -232,6 +261,10 @@ function SubmissionForm() {
                 <span>Floor selected</span>
               </div>
             )}
+            <div className={`status-item ${difficulty ? 'complete' : ''}`}>
+              <span className="status-icon">{difficulty ? '\u2713' : '\u25CB'}</span>
+              <span>Difficulty selected</span>
+            </div>
           </div>
         </div>
 

--- a/react-vite-app/src/components/SubmissionApp/SubmissionForm.test.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionForm.test.jsx
@@ -274,6 +274,19 @@ describe('SubmissionForm', () => {
       expect(screen.getByText('Please select a floor')).toBeInTheDocument();
     });
 
+    it('should show error when submitting without difficulty', async () => {
+      const user = userEvent.setup();
+      render(<SubmissionForm />);
+
+      // Upload a photo and select location (not in a region, so no floor needed)
+      await user.click(screen.getByText('Upload Photo'));
+      await user.click(screen.getByText('Click Map'));
+
+      await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
+
+      expect(screen.getByText('Please select a difficulty')).toBeInTheDocument();
+    });
+
     it('should not disable submit button initially (validation on submit)', () => {
       render(<SubmissionForm />);
       expect(screen.getByRole('button', { name: 'Submit Photo' })).not.toBeDisabled();
@@ -292,6 +305,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields (not in a region, so no floor needed)
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -314,6 +328,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -331,6 +346,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -353,6 +369,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -370,6 +387,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -388,6 +406,7 @@ describe('SubmissionForm', () => {
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
       await user.click(screen.getByTestId('floor-2'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -404,6 +423,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -420,6 +440,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -440,6 +461,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -458,6 +480,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));
@@ -476,6 +499,7 @@ describe('SubmissionForm', () => {
       // Fill in all fields
       await user.click(screen.getByText('Upload Photo'));
       await user.click(screen.getByText('Click Map'));
+      await user.click(screen.getByText('Easy'));
 
       // Submit
       await user.click(screen.getByRole('button', { name: 'Submit Photo' }));

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../../contexts/AuthContext';
 import './TitleScreen.css';
 
-function TitleScreen({ onStartGame, onOpenSubmission, onOpenProfile, isLoading }) {
+function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, isLoading }) {
   const { userDoc, logout } = useAuth();
 
   const handleLogout = async () => {
@@ -42,7 +42,7 @@ function TitleScreen({ onStartGame, onOpenSubmission, onOpenProfile, isLoading }
         <p className="tagline">Can you guess the location on campus?</p>
         <button
           className="start-button"
-          onClick={onStartGame}
+          onClick={onPlay}
           disabled={isLoading}
         >
           {isLoading ? (
@@ -51,7 +51,7 @@ function TitleScreen({ onStartGame, onOpenSubmission, onOpenProfile, isLoading }
               Loading...
             </>
           ) : (
-            'Start Game'
+            'Play'
           )}
         </button>
         <p className="subtitle">

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.test.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.test.jsx
@@ -24,7 +24,7 @@ vi.mock('../../contexts/AuthContext', () => ({
 
 describe('TitleScreen', () => {
   const defaultProps = {
-    onStartGame: vi.fn(),
+    onPlay: vi.fn(),
     onOpenSubmission: vi.fn(),
     onOpenProfile: vi.fn(),
     isLoading: false
@@ -59,10 +59,10 @@ describe('TitleScreen', () => {
       expect(screen.getByText('🌍')).toBeInTheDocument();
     });
 
-    it('should render the Start Game button', () => {
+    it('should render the Play button', () => {
       render(<TitleScreen {...defaultProps} />);
 
-      expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^play$/i })).toBeInTheDocument();
     });
 
     it('should render the Submit Photo button', () => {
@@ -72,16 +72,16 @@ describe('TitleScreen', () => {
     });
   });
 
-  describe('Start Game button', () => {
-    it('should call onStartGame when clicked', async () => {
+  describe('Play button', () => {
+    it('should call onPlay when clicked', async () => {
       const user = userEvent.setup();
-      const onStartGame = vi.fn();
+      const onPlay = vi.fn();
 
-      render(<TitleScreen {...defaultProps} onStartGame={onStartGame} />);
+      render(<TitleScreen {...defaultProps} onPlay={onPlay} />);
 
-      await user.click(screen.getByRole('button', { name: /start game/i }));
+      await user.click(screen.getByRole('button', { name: /^play$/i }));
 
-      expect(onStartGame).toHaveBeenCalledTimes(1);
+      expect(onPlay).toHaveBeenCalledTimes(1);
     });
 
     it('should be disabled when loading', () => {
@@ -99,19 +99,19 @@ describe('TitleScreen', () => {
     it('should not be disabled when not loading', () => {
       render(<TitleScreen {...defaultProps} isLoading={false} />);
 
-      expect(screen.getByRole('button', { name: /start game/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /^play$/i })).not.toBeDisabled();
     });
 
-    it('should not call onStartGame when disabled', async () => {
+    it('should not call onPlay when disabled', async () => {
       const user = userEvent.setup();
-      const onStartGame = vi.fn();
+      const onPlay = vi.fn();
 
-      render(<TitleScreen {...defaultProps} onStartGame={onStartGame} isLoading={true} />);
+      render(<TitleScreen {...defaultProps} onPlay={onPlay} isLoading={true} />);
 
       const button = screen.getByRole('button', { name: /loading/i });
       await user.click(button);
 
-      expect(onStartGame).not.toHaveBeenCalled();
+      expect(onPlay).not.toHaveBeenCalled();
     });
   });
 
@@ -132,7 +132,7 @@ describe('TitleScreen', () => {
     it('should have accessible button names', () => {
       render(<TitleScreen {...defaultProps} />);
 
-      expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^play$/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /submit photo/i })).toBeInTheDocument();
     });
 

--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -74,6 +74,9 @@ export function useGameState() {
   // Track when a click is rejected (outside playing area)
   const [clickRejected, setClickRejected] = useState(false);
 
+  // Selected difficulty for the current game
+  const [difficulty, setDifficulty] = useState(null);
+
   // Load regions and playing area on mount
   useEffect(() => {
     async function loadData() {
@@ -101,7 +104,7 @@ export function useGameState() {
     setError(null);
 
     try {
-      const image = await getRandomImage();
+      const image = await getRandomImage(difficulty);
       setCurrentImage(image);
       setGuessLocation(null);
       setGuessFloor(null);
@@ -113,15 +116,17 @@ export function useGameState() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [difficulty]);
 
   /**
    * Start a new game - reset everything and fetch first image
+   * @param {string} selectedDifficulty - 'easy', 'medium', or 'hard'
    */
-  const startGame = useCallback(async () => {
+  const startGame = useCallback(async (selectedDifficulty) => {
     setCurrentRound(1);
     setRoundResults([]);
     setCurrentResult(null);
+    setDifficulty(selectedDifficulty);
 
     setIsLoading(true);
     setError(null);
@@ -129,7 +134,7 @@ export function useGameState() {
     try {
       // Reload playing area and regions in case they were updated in the editor
       const [image, fetchedPlayingArea, fetchedRegions] = await Promise.all([
-        getRandomImage(),
+        getRandomImage(selectedDifficulty),
         getPlayingArea(),
         getRegions()
       ]);
@@ -356,6 +361,7 @@ export function useGameState() {
     setError(null);
     setTimeRemaining(ROUND_TIME_SECONDS);
     setRoundStartTime(null);
+    setDifficulty(null);
   }, []);
 
   return {
@@ -375,8 +381,10 @@ export function useGameState() {
     playingArea,
     timeRemaining,
     roundTimeSeconds: ROUND_TIME_SECONDS,
+    difficulty,
 
     // Actions
+    setScreen,
     startGame,
     placeMarker,
     selectFloor,

--- a/react-vite-app/src/hooks/useGameState.test.js
+++ b/react-vite-app/src/hooks/useGameState.test.js
@@ -109,7 +109,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.screen).toBe('game');
@@ -119,7 +119,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.currentImage).toEqual(mockImage);
@@ -129,7 +129,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(getRandomImage).toHaveBeenCalledTimes(1);
@@ -139,7 +139,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.currentRound).toBe(1);
@@ -149,7 +149,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.roundResults).toEqual([]);
@@ -168,7 +168,7 @@ describe('useGameState', () => {
 
       // Start the game (this will set isLoading = true before awaiting)
       act(() => {
-        result.current.startGame();
+        result.current.startGame('medium');
       });
 
       // After act completes, isLoading should be true while waiting for the promise
@@ -190,7 +190,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.error).toBe('Failed to load image. Please try again.');
@@ -203,14 +203,14 @@ describe('useGameState', () => {
       // First, cause an error
       getRandomImage.mockRejectedValueOnce(new Error('Network error'));
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
       expect(result.current.error).not.toBeNull();
 
       // Then, start successfully
       getRandomImage.mockResolvedValueOnce(mockImage);
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       expect(result.current.error).toBeNull();
@@ -222,7 +222,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -236,7 +236,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -256,7 +256,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -270,7 +270,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -290,7 +290,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -305,7 +305,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -338,7 +338,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -360,7 +360,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -383,7 +383,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -406,7 +406,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -429,7 +429,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -453,7 +453,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -476,7 +476,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -496,7 +496,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -517,7 +517,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -537,7 +537,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       // Play through 5 rounds
@@ -561,7 +561,7 @@ describe('useGameState', () => {
 
       // Start game successfully
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       // Complete first round
@@ -588,7 +588,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -610,7 +610,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -624,7 +624,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -648,7 +648,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -675,7 +675,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -706,7 +706,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -739,7 +739,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -763,7 +763,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -786,7 +786,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {
@@ -811,7 +811,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       // Round 1
@@ -853,7 +853,7 @@ describe('useGameState', () => {
       const { result } = renderHook(() => useGameState());
 
       await act(async () => {
-        await result.current.startGame();
+        await result.current.startGame('medium');
       });
 
       act(() => {


### PR DESCRIPTION
## Summary
- **New Difficulty Select screen**: After clicking "Play" on the title screen, players now choose a difficulty (Easy, Medium, Hard) before starting. Singleplayer is pre-selected; Multiplayer is grayed out with a "Coming Soon!" tooltip on hover.
- **Difficulty field on images**: Images now carry a `difficulty` property (`easy`, `medium`, `hard`). Only images matching the selected difficulty are shown during gameplay (falls back to all images if none match).
- **Submission & Admin support**: The photo submission form requires a difficulty selection. The admin review panel displays difficulty on cards/modals and allows editing it via a dropdown.

## Test plan
- [x] Verify clicking "Play" on the title screen navigates to the difficulty select screen
- [x] Verify selecting a difficulty and clicking "Play" starts a singleplayer game
- [x] Verify the multiplayer button is grayed out and shows "Coming Soon!" on hover
- [x] Verify the "← Back" button returns to the title screen
- [x] Verify only images matching the selected difficulty appear in game rounds
- [x] Verify the submission form includes the difficulty selector and requires it
- [x] Verify admin review cards show the difficulty badge
- [x] Verify difficulty can be edited in the admin edit modal for both submissions and game images
- [x] Verify "Play Again" from final results returns to difficulty select (not title)
- [x] All 142 tests across changed files pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)