### PR TITLE
Add 'All' difficulty option that shows any photo

### DIFF
--- a/react-vite-app/src/components/DifficultySelect/DifficultySelect.css
+++ b/react-vite-app/src/components/DifficultySelect/DifficultySelect.css
@@ -49,7 +49,7 @@
   align-items: center;
   text-align: center;
   padding: 2rem;
-  max-width: 700px;
+  max-width: 900px;
   width: 100%;
 }
 

--- a/react-vite-app/src/components/DifficultySelect/DifficultySelect.jsx
+++ b/react-vite-app/src/components/DifficultySelect/DifficultySelect.jsx
@@ -3,6 +3,12 @@ import './DifficultySelect.css';
 
 const DIFFICULTIES = [
   {
+    id: 'all',
+    label: 'All',
+    icon: '🌐',
+    description: 'Any photo, any difficulty',
+  },
+  {
     id: 'easy',
     label: 'Easy',
     icon: '🟢',

--- a/react-vite-app/src/services/imageService.js
+++ b/react-vite-app/src/services/imageService.js
@@ -49,7 +49,7 @@ const SAMPLE_IMAGES = [
  * Fetches a random image from all approved sources, optionally filtered by difficulty.
  * - Firestore 'images' collection (all are considered approved)
  * - Firestore 'submissions' collection with status 'approved'
- * @param {string|null} difficulty - 'easy', 'medium', 'hard', or null for all
+ * @param {string|null} difficulty - 'easy', 'medium', 'hard', 'all', or null for all
  */
 export async function getRandomImage(difficulty = null) {
   try {
@@ -71,7 +71,7 @@ export async function getRandomImage(difficulty = null) {
 /**
  * Fetches all approved images from both the images collection
  * and approved submissions, optionally filtered by difficulty.
- * @param {string|null} difficulty - 'easy', 'medium', 'hard', or null for all
+ * @param {string|null} difficulty - 'easy', 'medium', 'hard', 'all', or null for all
  */
 export async function getAllApprovedImages(difficulty = null) {
   try {
@@ -102,8 +102,8 @@ export async function getAllApprovedImages(difficulty = null) {
 
     let allImages = [...images, ...approvedSubmissions];
 
-    // Filter by difficulty if specified
-    if (difficulty) {
+    // Filter by difficulty if specified ('all' or null means no filter)
+    if (difficulty && difficulty !== 'all') {
       const filtered = allImages.filter(img => img.difficulty === difficulty);
       // Fall back to all images if none match the difficulty
       if (filtered.length > 0) {


### PR DESCRIPTION
## Summary
- Adds a new **"All"** difficulty option (🌐) to the difficulty selection screen that shows photos from any difficulty level
- Updates the image service filtering logic to skip filtering when `'all'` is selected, returning the full pool of approved images
- Widens the difficulty content container from 700px to 900px to accommodate the fourth card

## Test plan
- [ ] Verify the "All" card appears on the difficulty selection screen alongside Easy, Medium, and Hard
- [ ] Select "All" and start a game — confirm photos of any difficulty are shown
- [ ] Verify Easy, Medium, and Hard still filter correctly when selected
- [ ] Check responsive layout on mobile (cards should stack vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)