### PR TITLE
Add spacebar keyboard shortcuts for game flow navigation

### DIFF
--- a/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
+++ b/react-vite-app/src/components/FinalResultsScreen/FinalResultsScreen.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import './FinalResultsScreen.css';
 
 /**
@@ -38,6 +38,19 @@ function FinalResultsScreen({ rounds, onPlayAgain, onBackToTitle }) {
 
   // Generate confetti data once and memoize it
   const confettiPieces = useMemo(() => generateConfettiData(30), []);
+
+  // Spacebar to play again
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      onPlayAgain();
+    }
+  }, [onPlayAgain]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   // Animate total score
   useEffect(() => {

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useCallback } from 'react';
 import ImageViewer from '../ImageViewer/ImageViewer';
 import MapPicker from '../MapPicker/MapPicker';
 import FloorSelector from '../FloorSelector/FloorSelector';
@@ -25,6 +26,18 @@ function GameScreen({
   // - in a region with floors and a floor is selected
   const isInRegion = availableFloors !== null && availableFloors.length > 0;
   const canSubmit = guessLocation !== null && (!isInRegion || guessFloor !== null);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space' && canSubmit) {
+      e.preventDefault();
+      onSubmitGuess();
+    }
+  }, [canSubmit, onSubmitGuess]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <div className="game-screen">

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import useMapZoom from '../../hooks/useMapZoom';
 import './ResultScreen.css';
 
@@ -76,6 +76,23 @@ function ResultScreen({
 
     return () => timers.forEach(clearTimeout);
   }, []);
+
+  // Spacebar to advance to next round / final results
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (isLastRound) {
+        onViewFinalResults();
+      } else {
+        onNextRound();
+      }
+    }
+  }, [isLastRound, onNextRound, onViewFinalResults]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   // Animate score counter
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **GameScreen**: Spacebar now submits the guess when a location (and floor, if applicable) is selected
- **ResultScreen**: Spacebar advances to the next round (or views final results on the last round)
- **FinalResultsScreen**: Spacebar triggers "Play Again"

## Test plan
- [ ] Start a game, select a location on the map → press spacebar → guess should be submitted
- [ ] Start a game in a region with floors, select location only → press spacebar → nothing should happen (floor not yet selected)
- [ ] Select both location and floor → press spacebar → guess should be submitted
- [ ] On the result screen after a round → press spacebar → should advance to the next round
- [ ] On the result screen of the final round → press spacebar → should show final results
- [ ] On the final results screen → press spacebar → should start a new game

🤖 Generated with [Claude Code](https://claude.com/claude-code)