### PR TITLE
Scale results screen map to match details panel height

### DIFF
--- a/react-vite-app/src/components/ResultScreen/ResultScreen.css
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.css
@@ -82,13 +82,16 @@
   border-radius: 16px;
   padding: 1rem;
   border: 1px solid var(--border-color);
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .result-map {
   position: relative;
   width: 100%;
-  height: 100%;
-  min-height: 400px;
+  flex: 1;
+  min-height: 0;
   background-color: var(--bg-secondary);
   border-radius: 12px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Scaled the map on the results screen to have the same height as the right-side details panel (image preview, stats card, and next button)
- Changed `.result-map-container` to use flexbox so it properly fills its grid cell and passes height down to the map
- Changed `.result-map` from fixed `height: 100%` / `min-height: 400px` to `flex: 1` / `min-height: 0` so it expands to match the grid row height defined by the details panel

## Test plan
- [ ] Verify the map and details panel are the same height on the results screen
- [ ] Check responsive behavior at 900px and 600px breakpoints (single column layout)
- [ ] Confirm map zoom controls still function correctly
- [ ] Confirm all 39 existing ResultScreen tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)