### PR TITLE
Fix: Scale results screen map to match details panel height

### DIFF
--- a/react-vite-app/src/components/ResultScreen/ResultScreen.css
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.css
@@ -69,11 +69,9 @@
 
 /* Main Content */
 .result-content {
-  flex: 1;
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   gap: 1.5rem;
-  min-height: 0;
 }
 
 /* Map Container */
@@ -82,7 +80,6 @@
   border-radius: 16px;
   padding: 1rem;
   border: 1px solid var(--border-color);
-  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -91,7 +88,7 @@
   position: relative;
   width: 100%;
   flex: 1;
-  min-height: 0;
+  min-height: 300px;
   background-color: var(--bg-secondary);
   border-radius: 12px;
   overflow: hidden;
@@ -357,7 +354,6 @@
 
 /* Next Round Button */
 .next-round-button {
-  margin-top: auto;
   background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
   color: var(--text-primary);
   font-size: 1.1rem;
@@ -398,6 +394,7 @@
   justify-content: center;
   gap: 0.75rem;
   padding: 1.5rem 0 0.5rem;
+  margin-top: auto;
 }
 
 .progress-dot {
@@ -423,7 +420,6 @@
 @media (max-width: 900px) {
   .result-content {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto;
   }
 
   .result-map {


### PR DESCRIPTION
## Summary
- Removed `flex: 1` from `.result-content` so the CSS grid row height is driven by the right panel's **content height** (image preview + stats + button), not by the viewport
- The map column now matches that height via CSS Grid's default `align-items: stretch`
- Moved `margin-top: auto` from `.next-round-button` to `.round-progress` so progress dots still pin to the page bottom
- Restored `min-height: 300px` on `.result-map` as a sensible floor
- Cleaned up leftover `min-height: 0` and `grid-template-rows` overrides

## Why the previous PR didn't work
The previous change kept `flex: 1` on `.result-content`, which stretched the grid to fill the entire remaining viewport height. This meant the map's height was determined by the **viewport**, not by the right-side details panel — so both columns just grew to fill the screen rather than the map matching the panel.

## Test plan
- [ ] Verify the map and details panel visually align at the same height on the results screen
- [ ] Check responsive layout at 900px and 600px breakpoints (single column)
- [ ] Confirm map zoom controls still work
- [ ] All 39 existing ResultScreen tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)