### PR TITLE
Fix: Scale map to match details panel height using ResizeObserver

### DIFF
--- a/react-vite-app/src/components/ResultScreen/ResultScreen.css
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.css
@@ -72,6 +72,7 @@
   display: grid;
   grid-template-columns: 1.5fr 1fr;
   gap: 1.5rem;
+  align-items: start;
 }
 
 /* Map Container */
@@ -82,13 +83,15 @@
   border: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .result-map {
   position: relative;
   width: 100%;
   flex: 1;
-  min-height: 300px;
+  min-height: 0;
   background-color: var(--bg-secondary);
   border-radius: 12px;
   overflow: hidden;
@@ -420,6 +423,10 @@
 @media (max-width: 900px) {
   .result-content {
     grid-template-columns: 1fr;
+  }
+
+  .result-map-container {
+    height: auto !important;
   }
 
   .result-map {

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -41,8 +41,33 @@ function ResultScreen({
   isLastRound
 }) {
   const mapContainerRef = useRef(null);
+  const detailsRef = useRef(null);
+  const mapOuterRef = useRef(null);
   const [animationPhase, setAnimationPhase] = useState(0);
   const [displayedScore, setDisplayedScore] = useState(0);
+
+  // Sync map container height to match the details panel height
+  useEffect(() => {
+    const detailsEl = detailsRef.current;
+    const mapEl = mapOuterRef.current;
+    if (!detailsEl || !mapEl) return;
+
+    const syncHeight = () => {
+      const detailsHeight = detailsEl.offsetHeight;
+      if (detailsHeight > 0) {
+        mapEl.style.height = `${detailsHeight}px`;
+      }
+    };
+
+    // Initial sync
+    syncHeight();
+
+    // Re-sync whenever the details panel resizes (e.g. window resize, content change)
+    const observer = new ResizeObserver(syncHeight);
+    observer.observe(detailsEl);
+
+    return () => observer.disconnect();
+  }, []);
 
   const {
     scale,
@@ -141,7 +166,7 @@ function ResultScreen({
 
       {/* Main content - Map with results */}
       <div className="result-content">
-        <div className="result-map-container">
+        <div className="result-map-container" ref={mapOuterRef}>
           <div className="result-map" ref={mapContainerRef}>
             <div
               className="result-zoom-content"
@@ -249,7 +274,7 @@ function ResultScreen({
         </div>
 
         {/* Side panel with details */}
-        <div className="result-details">
+        <div className="result-details" ref={detailsRef}>
           <div className="result-image-preview">
             <img src={imageUrl} alt="Location" />
           </div>

--- a/react-vite-app/src/test/setup.js
+++ b/react-vite-app/src/test/setup.js
@@ -23,12 +23,17 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   disconnect: vi.fn(),
 }));
 
-// Mock ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
+// Mock ResizeObserver — stores callback so tests can trigger it
+global._resizeObserverInstances = [];
+global.ResizeObserver = class ResizeObserver {
+  constructor(callback) {
+    this._callback = callback;
+    this.observe = vi.fn();
+    this.unobserve = vi.fn();
+    this.disconnect = vi.fn();
+    global._resizeObserverInstances.push(this);
+  }
+};
 
 // Suppress console errors during tests (optional - can be removed if you want to see all errors)
 const originalError = console.error;


### PR DESCRIPTION
## Summary
The previous CSS-only attempts did not actually scale the map to match the right panel. CSS Grid's `align-items: stretch` only stretches the grid cell container — it doesn't make the map image visually scale. The map just got letterboxed inside an oversized container.

This fix uses **JavaScript with `ResizeObserver`** to explicitly sync the heights:
- Measures the `.result-details` panel's actual `offsetHeight`
- Sets that exact pixel height on `.result-map-container`
- Re-syncs automatically whenever the details panel resizes (window resize, content changes)

## Changes

### `ResultScreen.jsx`
- Added `detailsRef` and `mapOuterRef` refs
- Added `useEffect` with `ResizeObserver` that measures the details panel height and applies it to the map container
- Attached refs to `.result-map-container` and `.result-details` elements

### `ResultScreen.css`
- Added `align-items: start` to `.result-content` so the grid doesn't stretch the map beyond the JS-set height
- Added `overflow: hidden` and `box-sizing: border-box` on `.result-map-container` to properly clip within the explicit height
- Changed `.result-map` `min-height` to `0` (the JS height controls the sizing now)
- Added `height: auto !important` override for 900px mobile breakpoint (single column — no height sync needed)

### `setup.js`
- Fixed `ResizeObserver` mock to use a `class` instead of an arrow function (arrow functions can't be called with `new`)
- Stores observer instances in `global._resizeObserverInstances` so tests can trigger callbacks

### `ResultScreen.test.jsx`
- Added 3 new tests verifying the height sync:
  - Map container height is set to match details panel height (500px → 500px)
  - ResizeObserver properly observes the details panel
  - Map height updates dynamically when details panel resizes (400px → 600px)

## Test plan
- [x] All 42 tests pass (39 original + 3 new height sync tests)
- [ ] Verify visually that map and details panel are the same height
- [ ] Check responsive layout at 900px breakpoint (single column, no height sync)
- [ ] Confirm map zoom controls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)