### PR TITLE
Make points drop more dramatically with distance (k=10 → k=100)

### DIFF
--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -17,9 +17,9 @@ function calculateDistance(guess, actual) {
 
 /**
  * Calculate location score based on distance (0-5000 points)
- * Uses the GeoGuessr scoring formula: 5000 * e^(-10 * (d/D)^2)
+ * Uses a steep exponential decay formula: 5000 * e^(-100 * (d/D)^2)
  * At 10 ft (distance=5 in map coords) or closer, the player gets 5000.
- * Score decays to 0 at the maximum possible distance (map diagonal).
+ * Score drops very dramatically with distance, rewarding precise guesses.
  */
 function calculateLocationScore(distance) {
   const maxScore = 5000;
@@ -30,7 +30,7 @@ function calculateLocationScore(distance) {
 
   const effectiveDistance = distance - perfectRadius;
   const ratio = effectiveDistance / maxDistance;
-  const score = Math.round(maxScore * Math.exp(-10 * ratio * ratio));
+  const score = Math.round(maxScore * Math.exp(-100 * ratio * ratio));
   return Math.max(0, Math.min(maxScore, score));
 }
 

--- a/react-vite-app/src/hooks/useGameState.test.js
+++ b/react-vite-app/src/hooks/useGameState.test.js
@@ -801,10 +801,10 @@ describe('useGameState', () => {
         result.current.submitGuess();
       });
 
-      // GeoGuessr-style: distance=10, perfectRadius=5, effectiveDistance=5
+      // Steep decay: distance=10, perfectRadius=5, effectiveDistance=5
       // maxDistance = sqrt(100^2+100^2) - 5 ≈ 136.42
-      // ratio = 5/136.42 ≈ 0.0366, score = 5000 * e^(-10 * 0.0366^2) ≈ 4933
-      expect(result.current.currentResult.locationScore).toBeCloseTo(4933, -2);
+      // ratio = 5/136.42 ≈ 0.0366, score = 5000 * e^(-100 * 0.0366^2) ≈ 4372
+      expect(result.current.currentResult.locationScore).toBeCloseTo(4372, -2);
     });
   });
 

--- a/react-vite-app/src/utils/scoring.test.js
+++ b/react-vite-app/src/utils/scoring.test.js
@@ -13,9 +13,9 @@ function calculateDistance(guess, actual) {
 }
 
 /**
- * GeoGuessr-style scoring: 5000 * e^(-10 * (d/D)^2)
+ * Steep exponential decay scoring: 5000 * e^(-100 * (d/D)^2)
  * At 10 ft (distance=5) or closer → 5000 points.
- * Score decays to 0 at maximum possible distance (map diagonal).
+ * Score drops very dramatically with distance, rewarding precise guesses.
  */
 function calculateLocationScore(distance) {
   const maxScore = 5000;
@@ -26,7 +26,7 @@ function calculateLocationScore(distance) {
 
   const effectiveDistance = distance - perfectRadius;
   const ratio = effectiveDistance / maxDistance;
-  const score = Math.round(maxScore * Math.exp(-10 * ratio * ratio));
+  const score = Math.round(maxScore * Math.exp(-100 * ratio * ratio));
   return Math.max(0, Math.min(maxScore, score));
 }
 
@@ -131,18 +131,18 @@ describe('scoring utilities', () => {
       expect(score20).toBeGreaterThan(score30);
     });
 
-    it('should use GeoGuessr-style decay (score at 10 map units / 20 ft)', () => {
+    it('should use steep decay (score at 10 map units / 20 ft)', () => {
       const score = calculateLocationScore(10);
       // effectiveDistance = 5, ratio = 5/136.42 ≈ 0.0366
-      // 5000 * e^(-10 * 0.0366^2) ≈ 4933
-      expect(score).toBeCloseTo(4933, -2);
+      // 5000 * e^(-100 * 0.0366^2) ≈ 4372
+      expect(score).toBeCloseTo(4372, -2);
     });
 
-    it('should use GeoGuessr-style decay (score at 20 map units / 40 ft)', () => {
+    it('should use steep decay (score at 20 map units / 40 ft)', () => {
       const score = calculateLocationScore(20);
       // effectiveDistance = 15, ratio = 15/136.42 ≈ 0.1099
-      // 5000 * e^(-10 * 0.1099^2) ≈ 4431
-      expect(score).toBeCloseTo(4431, -2);
+      // 5000 * e^(-100 * 0.1099^2) ≈ 1493
+      expect(score).toBeCloseTo(1493, -2);
     });
 
     it('should approach 0 at maximum map distance', () => {


### PR DESCRIPTION
## Summary
- Increased the exponential decay factor in the scoring formula from `k=10` to `k=100` (`5000 × e^(-k × (d/D)²)`)
- Points now drop off very steeply with distance, heavily rewarding precise guesses
- Updated all related test assertions to match the new scoring curve

| Distance | Before (k=10) | After (k=100) |
|----------|---------------|----------------|
| 10 ft | 5,000 | 5,000 |
| 20 ft | 4,933 | 4,372 |
| 30 ft | 4,738 | 2,922 |
| 40 ft | 4,431 | 1,493 |
| 60 ft | 3,574 | 174 |
| 100 ft | 1,684 | 0 |

## Test plan
- [x] All 710 tests pass (excluding pre-existing `projectHealth.test.js` recursive meta-test issue)
- [ ] Verify in-game scoring feels appropriately punishing for inaccurate guesses
- [ ] Confirm perfect-radius guesses (≤10 ft) still receive full 5,000 points

🤖 Generated with [Claude Code](https://claude.com/claude-code)