### PR TITLE
Fix edit popup in manage accounts to be a true modal

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import { isHardcodedAdmin } from '../../services/userService'
 import './UserEditModal.css'
 
@@ -64,7 +65,7 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
     })
   }
 
-  return (
+  return createPortal(
     <div className="user-modal-overlay" onClick={onClose}>
       <div className="user-modal-content" onClick={e => e.stopPropagation()}>
         <button className="user-modal-close" onClick={onClose}>&times;</button>
@@ -164,7 +165,8 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
           </div>
         </form>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 


### PR DESCRIPTION
## Summary
- **Fixed the edit popup in the Manage Accounts admin page** so it behaves as a true fullscreen modal overlay instead of being trapped inside the admin content area.
- Used React `createPortal` to render `UserEditModal` directly on `document.body`, escaping ancestor containers whose `overflow: hidden` and `backdrop-filter` CSS properties were breaking `position: fixed`.

## Test plan
- [ ] Navigate to Admin → Manage Accounts
- [ ] Click "Edit" on any user row
- [ ] Verify the modal covers the full viewport with a blurred backdrop overlay
- [ ] Verify the modal is centered on screen, not clipped inside the admin content box
- [ ] Verify Save and Cancel buttons work correctly
- [ ] Test on mobile viewport sizes to confirm responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)