### PR TITLE
Make all user fields editable in admin Edit User popup

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.css
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.css
@@ -27,7 +27,7 @@
   background: linear-gradient(145deg, #1e1e3a 0%, #161630 100%);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 24px;
-  max-width: 500px;
+  max-width: 560px;
   width: 100%;
   max-height: 90vh;
   overflow-y: auto;
@@ -98,7 +98,46 @@
 .user-modal-form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 8px;
+}
+
+/* ===== Sections ===== */
+.user-modal-section {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.user-modal-section-header {
+  font-size: 13px;
+  font-weight: 700;
+  color: #a78bfa;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.12);
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.user-modal-section-hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: #6b7280;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* ===== Field rows (side by side) ===== */
+.user-modal-field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
 }
 
 /* Field rows */
@@ -127,6 +166,8 @@
   color: #e0e6f0;
   background: rgba(255, 255, 255, 0.04);
   transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .user-modal-input:focus {
@@ -140,6 +181,78 @@
   opacity: 0.5;
   background: rgba(255, 255, 255, 0.02);
   cursor: not-allowed;
+}
+
+/* Number input with icon + unit */
+.user-modal-number-wrapper {
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.user-modal-number-wrapper:focus-within {
+  border-color: rgba(139, 92, 246, 0.5);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.user-modal-number-icon {
+  padding: 0 0 0 12px;
+  font-size: 16px;
+  flex-shrink: 0;
+  color: #a78bfa;
+}
+
+.user-modal-input-number {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  padding: 12px 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.user-modal-input-number:focus {
+  outline: none;
+  border-color: transparent;
+  box-shadow: none;
+  background: transparent;
+}
+
+.user-modal-number-unit {
+  padding: 0 14px 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+/* Hide number input spinners for cleaner look */
+.user-modal-input-number::-webkit-outer-spin-button,
+.user-modal-input-number::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.user-modal-input-number[type=number] {
+  -moz-appearance: textfield;
+}
+
+/* Field hints — shows current value below inputs */
+.user-modal-field-hint {
+  font-size: 11px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* datetime-local styling */
+.user-modal-input[type="datetime-local"] {
+  color-scheme: dark;
 }
 
 /* Read-only values */
@@ -241,6 +354,19 @@
     padding: 22px;
     margin: 10px;
     border-radius: 20px;
+  }
+
+  .user-modal-section {
+    padding: 14px;
+  }
+
+  .user-modal-field-row {
+    grid-template-columns: 1fr;
+  }
+
+  .user-modal-section-header {
+    flex-direction: column;
+    gap: 4px;
   }
 
   .user-modal-actions {

--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
@@ -3,20 +3,43 @@ import { isHardcodedAdmin } from '../../services/userService'
 import './UserEditModal.css'
 
 function UserEditModal({ user, onSave, onClose, isSaving }) {
+  // System fields that are never editable
+  const systemFields = ['uid', 'id', 'createdAt']
+  // Known fields we render explicitly with nice UI
+  const knownFields = ['uid', 'id', 'email', 'username', 'isAdmin', 'createdAt', 'totalXp', 'gamesPlayed', 'lastGameAt']
+
+  // Extra/dynamic fields beyond the known set
+  const extraFields = Object.keys(user).filter(
+    key => !knownFields.includes(key)
+  )
+
+  const toDatetimeLocal = (timestamp) => {
+    if (!timestamp) return ''
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
+    if (isNaN(date.getTime())) return ''
+    // Format as YYYY-MM-DDTHH:MM for datetime-local input
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  }
+
   const [formData, setFormData] = useState({
     username: user.username || '',
     email: user.email || '',
     isAdmin: user.isAdmin || false,
+    totalXp: user.totalXp ?? 0,
+    gamesPlayed: user.gamesPlayed ?? 0,
+    lastGameAt: toDatetimeLocal(user.lastGameAt),
+    // Initialize extra fields
+    ...Object.fromEntries(
+      extraFields.map(key => [
+        key,
+        typeof user[key] === 'object' ? JSON.stringify(user[key]) : String(user[key] ?? '')
+      ])
+    ),
   })
   const [error, setError] = useState(null)
 
   const hardcoded = isHardcodedAdmin(user.id)
-
-  // Identify extra fields beyond the standard set
-  const standardFields = ['uid', 'email', 'username', 'isAdmin', 'createdAt']
-  const extraFields = Object.keys(user).filter(
-    key => !standardFields.includes(key) && key !== 'id'
-  )
 
   const handleChange = (field, value) => {
     setFormData(prev => ({ ...prev, [field]: value }))
@@ -29,6 +52,7 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
 
     // Build updates object with only changed fields
     const updates = {}
+
     if (formData.username !== (user.username || '')) {
       updates.username = formData.username
     }
@@ -37,6 +61,52 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
     }
     if (formData.isAdmin !== (user.isAdmin || false)) {
       updates.isAdmin = formData.isAdmin
+    }
+
+    // XP & Stats — compare numerically
+    const newTotalXp = Number(formData.totalXp)
+    if (!isNaN(newTotalXp) && newTotalXp !== (user.totalXp ?? 0)) {
+      updates.totalXp = newTotalXp
+    }
+    const newGamesPlayed = Number(formData.gamesPlayed)
+    if (!isNaN(newGamesPlayed) && newGamesPlayed !== (user.gamesPlayed ?? 0)) {
+      updates.gamesPlayed = newGamesPlayed
+    }
+
+    // lastGameAt — compare as date
+    if (formData.lastGameAt) {
+      const newDate = new Date(formData.lastGameAt)
+      const oldDate = user.lastGameAt
+        ? (user.lastGameAt.toDate ? user.lastGameAt.toDate() : new Date(user.lastGameAt))
+        : null
+      if (!oldDate || newDate.getTime() !== oldDate.getTime()) {
+        updates.lastGameAt = newDate
+      }
+    } else if (user.lastGameAt) {
+      // Cleared the date
+      updates.lastGameAt = null
+    }
+
+    // Extra/dynamic fields
+    for (const field of extraFields) {
+      const original = typeof user[field] === 'object'
+        ? JSON.stringify(user[field])
+        : String(user[field] ?? '')
+      if (formData[field] !== original) {
+        // Try to parse back to number or JSON if applicable
+        const val = formData[field]
+        if (val === '') {
+          updates[field] = ''
+        } else if (!isNaN(Number(val)) && val.trim() !== '') {
+          updates[field] = Number(val)
+        } else {
+          try {
+            updates[field] = JSON.parse(val)
+          } catch {
+            updates[field] = val
+          }
+        }
+      }
     }
 
     // Nothing changed — just close
@@ -74,75 +144,170 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
         {error && <div className="user-modal-error">{error}</div>}
 
         <form onSubmit={handleSubmit} className="user-modal-form">
-          {/* Read-only: UID */}
-          <div className="user-modal-field">
-            <label className="user-modal-label">User ID</label>
-            <span className="user-modal-value user-modal-uid">{user.id}</span>
+          {/* ────── Identity Section ────── */}
+          <div className="user-modal-section">
+            <div className="user-modal-section-header">Identity</div>
+
+            {/* Read-only: UID */}
+            <div className="user-modal-field">
+              <label className="user-modal-label">User ID</label>
+              <span className="user-modal-value user-modal-uid">{user.id}</span>
+            </div>
+
+            {/* Editable: Username */}
+            <div className="user-modal-field">
+              <label className="user-modal-label" htmlFor="edit-username">Username</label>
+              <input
+                id="edit-username"
+                type="text"
+                className="user-modal-input"
+                value={formData.username}
+                onChange={(e) => handleChange('username', e.target.value)}
+                disabled={isSaving}
+              />
+            </div>
+
+            {/* Editable: Email */}
+            <div className="user-modal-field">
+              <label className="user-modal-label" htmlFor="edit-email">Email</label>
+              <input
+                id="edit-email"
+                type="email"
+                className="user-modal-input"
+                value={formData.email}
+                onChange={(e) => handleChange('email', e.target.value)}
+                disabled={isSaving}
+              />
+            </div>
           </div>
 
-          {/* Editable: Username */}
-          <div className="user-modal-field">
-            <label className="user-modal-label" htmlFor="edit-username">Username</label>
-            <input
-              id="edit-username"
-              type="text"
-              className="user-modal-input"
-              value={formData.username}
-              onChange={(e) => handleChange('username', e.target.value)}
-              disabled={isSaving}
-            />
+          {/* ────── Permissions Section ────── */}
+          <div className="user-modal-section">
+            <div className="user-modal-section-header">Permissions</div>
+
+            {/* Editable: Admin toggle (unless hardcoded) */}
+            <div className="user-modal-field">
+              <label className="user-modal-label">Admin Status</label>
+              {hardcoded ? (
+                <span className="user-modal-value user-modal-locked">
+                  Always Admin (Permanent)
+                </span>
+              ) : (
+                <label className="user-modal-checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={formData.isAdmin}
+                    onChange={(e) => handleChange('isAdmin', e.target.checked)}
+                    disabled={isSaving}
+                  />
+                  <span>{formData.isAdmin ? 'Admin' : 'Not Admin'}</span>
+                </label>
+              )}
+            </div>
           </div>
 
-          {/* Editable: Email */}
-          <div className="user-modal-field">
-            <label className="user-modal-label" htmlFor="edit-email">Email</label>
-            <input
-              id="edit-email"
-              type="email"
-              className="user-modal-input"
-              value={formData.email}
-              onChange={(e) => handleChange('email', e.target.value)}
-              disabled={isSaving}
-            />
-          </div>
+          {/* ────── XP & Stats Section ────── */}
+          <div className="user-modal-section">
+            <div className="user-modal-section-header">
+              XP &amp; Stats
+              <span className="user-modal-section-hint">Directly overwrite player progression values</span>
+            </div>
 
-          {/* Editable: Admin toggle (unless hardcoded) */}
-          <div className="user-modal-field">
-            <label className="user-modal-label">Admin Status</label>
-            {hardcoded ? (
-              <span className="user-modal-value user-modal-locked">
-                Always Admin (Permanent)
-              </span>
-            ) : (
-              <label className="user-modal-checkbox-label">
-                <input
-                  type="checkbox"
-                  checked={formData.isAdmin}
-                  onChange={(e) => handleChange('isAdmin', e.target.checked)}
-                  disabled={isSaving}
-                />
-                <span>{formData.isAdmin ? 'Admin' : 'Not Admin'}</span>
-              </label>
-            )}
-          </div>
+            <div className="user-modal-field-row">
+              {/* Editable: Total XP */}
+              <div className="user-modal-field">
+                <label className="user-modal-label" htmlFor="edit-totalXp">Total XP</label>
+                <div className="user-modal-number-wrapper">
+                  <span className="user-modal-number-icon">✦</span>
+                  <input
+                    id="edit-totalXp"
+                    type="number"
+                    min="0"
+                    className="user-modal-input user-modal-input-number"
+                    value={formData.totalXp}
+                    onChange={(e) => handleChange('totalXp', e.target.value)}
+                    disabled={isSaving}
+                  />
+                  <span className="user-modal-number-unit">XP</span>
+                </div>
+                <span className="user-modal-field-hint">
+                  {user.totalXp != null ? `Currently ${Number(user.totalXp).toLocaleString()} XP` : 'No XP recorded'}
+                </span>
+              </div>
 
-          {/* Read-only: Created At */}
-          <div className="user-modal-field">
-            <label className="user-modal-label">Created</label>
-            <span className="user-modal-value">{formatDate(user.createdAt)}</span>
-          </div>
+              {/* Editable: Games Played */}
+              <div className="user-modal-field">
+                <label className="user-modal-label" htmlFor="edit-gamesPlayed">Games Played</label>
+                <div className="user-modal-number-wrapper">
+                  <span className="user-modal-number-icon">🎮</span>
+                  <input
+                    id="edit-gamesPlayed"
+                    type="number"
+                    min="0"
+                    className="user-modal-input user-modal-input-number"
+                    value={formData.gamesPlayed}
+                    onChange={(e) => handleChange('gamesPlayed', e.target.value)}
+                    disabled={isSaving}
+                  />
+                  <span className="user-modal-number-unit">games</span>
+                </div>
+                <span className="user-modal-field-hint">
+                  {user.gamesPlayed != null ? `Currently ${Number(user.gamesPlayed).toLocaleString()} games` : 'No games recorded'}
+                </span>
+              </div>
+            </div>
 
-          {/* Any extra/dynamic fields — displayed read-only */}
-          {extraFields.map(field => (
-            <div className="user-modal-field" key={field}>
-              <label className="user-modal-label">{field}</label>
-              <span className="user-modal-value">
-                {typeof user[field] === 'object'
-                  ? JSON.stringify(user[field])
-                  : String(user[field])}
+            {/* Editable: Last Game At */}
+            <div className="user-modal-field">
+              <label className="user-modal-label" htmlFor="edit-lastGameAt">Last Game At</label>
+              <input
+                id="edit-lastGameAt"
+                type="datetime-local"
+                className="user-modal-input"
+                value={formData.lastGameAt}
+                onChange={(e) => handleChange('lastGameAt', e.target.value)}
+                disabled={isSaving}
+              />
+              <span className="user-modal-field-hint">
+                {user.lastGameAt ? `Currently ${formatDate(user.lastGameAt)}` : 'Never played'}
               </span>
             </div>
-          ))}
+          </div>
+
+          {/* ────── Timestamps Section ────── */}
+          <div className="user-modal-section">
+            <div className="user-modal-section-header">Timestamps</div>
+
+            {/* Read-only: Created At */}
+            <div className="user-modal-field">
+              <label className="user-modal-label">Created</label>
+              <span className="user-modal-value">{formatDate(user.createdAt)}</span>
+            </div>
+          </div>
+
+          {/* ────── Extra/Dynamic Fields Section ────── */}
+          {extraFields.length > 0 && (
+            <div className="user-modal-section">
+              <div className="user-modal-section-header">
+                Other Fields
+                <span className="user-modal-section-hint">Additional data stored on this user</span>
+              </div>
+
+              {extraFields.map(field => (
+                <div className="user-modal-field" key={field}>
+                  <label className="user-modal-label" htmlFor={`edit-extra-${field}`}>{field}</label>
+                  <input
+                    id={`edit-extra-${field}`}
+                    type="text"
+                    className="user-modal-input"
+                    value={formData[field]}
+                    onChange={(e) => handleChange(field, e.target.value)}
+                    disabled={isSaving}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
 
           {/* Actions */}
           <div className="user-modal-actions">

--- a/react-vite-app/src/services/userService.js
+++ b/react-vite-app/src/services/userService.js
@@ -139,5 +139,32 @@ export async function updateUserProfile(uid, updates) {
     updates.username = trimmed;
   }
 
+  // Validate totalXp if being changed
+  if ('totalXp' in updates) {
+    const xp = Number(updates.totalXp);
+    if (isNaN(xp) || xp < 0) {
+      throw new Error('Total XP must be a non-negative number.');
+    }
+    updates.totalXp = xp;
+  }
+
+  // Validate gamesPlayed if being changed
+  if ('gamesPlayed' in updates) {
+    const gp = Number(updates.gamesPlayed);
+    if (isNaN(gp) || gp < 0 || !Number.isInteger(gp)) {
+      throw new Error('Games played must be a non-negative whole number.');
+    }
+    updates.gamesPlayed = gp;
+  }
+
+  // Convert lastGameAt to a Firestore-compatible Date if provided
+  if ('lastGameAt' in updates && updates.lastGameAt !== null) {
+    const date = updates.lastGameAt instanceof Date ? updates.lastGameAt : new Date(updates.lastGameAt);
+    if (isNaN(date.getTime())) {
+      throw new Error('Last game date is invalid.');
+    }
+    updates.lastGameAt = date;
+  }
+
   await updateUserDoc(uid, updates);
 }


### PR DESCRIPTION
## Summary
- **Restructured the Edit User modal** into clear, labeled sections: Identity, Permissions, XP & Stats, Timestamps, and Other Fields
- **Made XP & Stats fully editable** — Total XP and Games Played use decorated number inputs with icons (✦ / 🎮), unit labels, and "currently X" hints so it's obvious what you're changing
- **Added Last Game At datetime picker** with current-value hint
- **Made all extra/dynamic Firestore fields editable** (previously read-only) with smart type coercion back to numbers/JSON on save
- **Added server-side validation** in `updateUserProfile` for `totalXp` (non-negative number), `gamesPlayed` (non-negative integer), and `lastGameAt` (valid date)

## Test plan
- [ ] Open Admin → Manage Accounts → click Edit on a user
- [ ] Verify all sections render: Identity, Permissions, XP & Stats, Timestamps
- [ ] Edit Total XP and Games Played — confirm current values shown as hints, values save correctly
- [ ] Edit Last Game At via datetime picker — confirm it persists to Firestore
- [ ] Verify validation: negative XP shows error, non-integer games played shows error
- [ ] Verify extra/dynamic fields appear and are editable if the user has any
- [ ] Confirm read-only fields (UID, Created) cannot be modified
- [ ] Confirm hardcoded admin still shows "Always Admin (Permanent)"
- [ ] Test responsive layout on mobile (fields should stack vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)