### PR TITLE
Add email verification for email/password signups

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -9,6 +9,7 @@ import GameScreen from './components/GameScreen/GameScreen';
 import ResultScreen from './components/ResultScreen/ResultScreen';
 import FinalResultsScreen from './components/FinalResultsScreen/FinalResultsScreen';
 import SubmissionApp from './components/SubmissionApp/SubmissionApp';
+import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';
 import './App.css';
 
 function App() {
@@ -62,18 +63,29 @@ function App() {
 
   // Show profile screen
   if (showProfile) {
-    return <ProfileScreen onBack={() => setShowProfile(false)} />;
+    return (
+      <>
+        <EmailVerificationBanner />
+        <ProfileScreen onBack={() => setShowProfile(false)} />
+      </>
+    );
   }
 
   // Show submission app
   if (showSubmissionApp) {
-    return <SubmissionApp onBack={() => setShowSubmissionApp(false)} />;
+    return (
+      <>
+        <EmailVerificationBanner />
+        <SubmissionApp onBack={() => setShowSubmissionApp(false)} />
+      </>
+    );
   }
 
   // Error state
   if (error) {
     return (
       <div className="app">
+        <EmailVerificationBanner />
         <div className="error-container">
           <p className="error-message">{error}</p>
           <button className="retry-button" onClick={resetGame}>
@@ -107,6 +119,7 @@ function App() {
 
   return (
     <div className="app">
+      <EmailVerificationBanner />
       {screen === 'title' && (
         <TitleScreen
           onPlay={handlePlay}

--- a/react-vite-app/src/components/EmailVerificationBanner/EmailVerificationBanner.css
+++ b/react-vite-app/src/components/EmailVerificationBanner/EmailVerificationBanner.css
@@ -1,0 +1,76 @@
+.email-verification-banner {
+  position: relative;
+  z-index: 1000;
+  width: 100%;
+  background: rgba(251, 191, 36, 0.12);
+  border-bottom: 1px solid rgba(251, 191, 36, 0.25);
+}
+
+.email-verification-banner-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  flex-wrap: wrap;
+}
+
+.email-verification-banner-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.email-verification-banner-text {
+  color: #fbbf24;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.email-verification-banner-resend {
+  background: rgba(251, 191, 36, 0.2);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  border-radius: 6px;
+  color: #fbbf24;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.email-verification-banner-resend:hover:not(:disabled) {
+  background: rgba(251, 191, 36, 0.3);
+}
+
+.email-verification-banner-resend:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.email-verification-banner-dismiss {
+  background: none;
+  border: none;
+  color: rgba(251, 191, 36, 0.6);
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.email-verification-banner-dismiss:hover {
+  color: #fbbf24;
+}
+
+@media (max-width: 480px) {
+  .email-verification-banner-content {
+    flex-direction: column;
+    text-align: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+}

--- a/react-vite-app/src/components/EmailVerificationBanner/EmailVerificationBanner.jsx
+++ b/react-vite-app/src/components/EmailVerificationBanner/EmailVerificationBanner.jsx
@@ -1,0 +1,80 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import './EmailVerificationBanner.css';
+
+function EmailVerificationBanner() {
+  const { user, emailVerified, sendVerificationEmail } = useAuth();
+  const [dismissed, setDismissed] = useState(false);
+  const [resendStatus, setResendStatus] = useState('idle'); // 'idle' | 'sending' | 'sent' | 'error'
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+
+  // Manage cooldown timer
+  useEffect(() => {
+    if (cooldownSeconds <= 0) return;
+
+    const timer = setTimeout(() => {
+      setCooldownSeconds(prev => {
+        const next = prev - 1;
+        if (next <= 0) {
+          setResendStatus('idle');
+        }
+        return next;
+      });
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [cooldownSeconds]);
+
+  const handleResend = useCallback(async () => {
+    if (cooldownSeconds > 0 || resendStatus === 'sending') return;
+
+    setResendStatus('sending');
+    try {
+      await sendVerificationEmail();
+      setResendStatus('sent');
+      setCooldownSeconds(60);
+    } catch {
+      setResendStatus('error');
+      setTimeout(() => setResendStatus('idle'), 3000);
+    }
+  }, [cooldownSeconds, resendStatus, sendVerificationEmail]);
+
+  // Don't show banner if: no user, already verified, Google user, or dismissed
+  const isGoogleUser = user?.providerData?.some(p => p.providerId === 'google.com');
+  if (!user || emailVerified || isGoogleUser || dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="email-verification-banner">
+      <div className="email-verification-banner-content">
+        <span className="email-verification-banner-icon">&#9993;</span>
+        <span className="email-verification-banner-text">
+          Please verify your email address. Check your inbox for a verification link.
+        </span>
+        <button
+          className="email-verification-banner-resend"
+          onClick={handleResend}
+          disabled={resendStatus === 'sending' || cooldownSeconds > 0}
+        >
+          {resendStatus === 'sending'
+            ? 'Sending...'
+            : resendStatus === 'sent'
+              ? `Sent! (${cooldownSeconds}s)`
+              : resendStatus === 'error'
+                ? 'Failed \u2014 Retry'
+                : 'Resend Email'}
+        </button>
+        <button
+          className="email-verification-banner-dismiss"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default EmailVerificationBanner;

--- a/react-vite-app/src/components/ProfileScreen/ProfileScreen.css
+++ b/react-vite-app/src/components/ProfileScreen/ProfileScreen.css
@@ -341,6 +341,30 @@
   cursor: not-allowed;
 }
 
+/* Email Verification Badge */
+.profile-verification-badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.profile-verification-badge.verified {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+.profile-verification-badge.unverified {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.2);
+}
+
 /* Responsive */
 @media (max-width: 480px) {
   .profile-card {

--- a/react-vite-app/src/components/ProfileScreen/ProfileScreen.jsx
+++ b/react-vite-app/src/components/ProfileScreen/ProfileScreen.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import './ProfileScreen.css';
 
 function ProfileScreen({ onBack }) {
-  const { user, userDoc, updateUsername, totalXp, levelInfo, levelTitle } = useAuth();
+  const { user, userDoc, updateUsername, totalXp, levelInfo, levelTitle, emailVerified } = useAuth();
 
   const [newUsername, setNewUsername] = useState(userDoc?.username || '');
   const [isEditing, setIsEditing] = useState(false);
@@ -153,7 +153,12 @@ function ProfileScreen({ onBack }) {
 
           <div className="profile-field">
             <span className="profile-label">Email</span>
-            <span className="profile-value">{user?.email}</span>
+            <div className="profile-value-row">
+              <span className="profile-value">{user?.email}</span>
+              <span className={`profile-verification-badge ${emailVerified ? 'verified' : 'unverified'}`}>
+                {emailVerified ? 'Verified' : 'Unverified'}
+              </span>
+            </div>
           </div>
 
           <div className="profile-field">


### PR DESCRIPTION
## Summary
- **Sends a verification email** automatically when a user signs up with email/password
- **Shows an amber banner** at the top of all authenticated screens for unverified email users, with a "Resend Email" button (60s cooldown) and a dismiss button (session-only — returns on page reload)
- **Detects verification** automatically via window focus listener and 30-second polling (`user.reload()`)
- **Google sign-in users are excluded** from the banner since they're already verified by Google
- **Profile screen** now displays a "Verified" (green) or "Unverified" (amber) badge next to the email address

## Test plan
- [ ] Sign up with email/password → verification email arrives, amber banner appears at top
- [ ] Click "Resend Email" on the banner → email resends, button shows 60s cooldown
- [ ] Dismiss the banner → disappears; refresh page → banner reappears
- [ ] Click verification link in email → switch back to app tab → banner auto-disappears
- [ ] Sign in with Google → no banner appears
- [ ] Check Profile screen → "Verified" or "Unverified" badge next to email
- [ ] Already-verified email/password user logs in → no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)