### PR TITLE
Add verified status to account admin panel

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/AccountManagement.css
+++ b/react-vite-app/src/components/SubmissionApp/AccountManagement.css
@@ -148,6 +148,29 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
+/* ===== Verified Status Badge ===== */
+.verified-status {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.verified-status.is-verified {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.2);
+}
+
+.verified-status.not-verified {
+  background: rgba(255, 255, 255, 0.04);
+  color: #6b7280;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
 /* ===== Action Buttons ===== */
 .actions-cell {
   display: flex;

--- a/react-vite-app/src/components/SubmissionApp/AccountManagement.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AccountManagement.jsx
@@ -121,6 +121,7 @@ function AccountManagement() {
               <th>Email</th>
               <th>Created</th>
               <th>Admin</th>
+              <th>Verified</th>
               <th>Status</th>
               <th>Activity</th>
               <th>Actions</th>
@@ -142,6 +143,11 @@ function AccountManagement() {
                   <td>
                     <span className={`admin-status ${u.isAdmin ? 'is-admin' : 'not-admin'}`}>
                       {u.isAdmin ? 'Yes' : 'No'}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`verified-status ${u.verified ? 'is-verified' : 'not-verified'}`}>
+                      {u.verified ? 'Yes' : 'No'}
                     </span>
                   </td>
                   <td>

--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
@@ -5,7 +5,7 @@ import './UserEditModal.css'
 
 function UserEditModal({ user, onSave, onClose, isSaving }) {
   // Known fields we render explicitly with nice UI
-  const knownFields = ['uid', 'id', 'email', 'username', 'isAdmin', 'createdAt', 'totalXp', 'gamesPlayed', 'lastGameAt']
+  const knownFields = ['uid', 'id', 'email', 'username', 'isAdmin', 'verified', 'createdAt', 'totalXp', 'gamesPlayed', 'lastGameAt']
 
   // Extra/dynamic fields beyond the known set
   const extraFields = Object.keys(user).filter(
@@ -25,6 +25,7 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
     username: user.username || '',
     email: user.email || '',
     isAdmin: user.isAdmin || false,
+    verified: user.verified || false,
     totalXp: user.totalXp ?? 0,
     gamesPlayed: user.gamesPlayed ?? 0,
     lastGameAt: toDatetimeLocal(user.lastGameAt),
@@ -60,6 +61,9 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
     }
     if (formData.isAdmin !== (user.isAdmin || false)) {
       updates.isAdmin = formData.isAdmin
+    }
+    if (formData.verified !== (user.verified || false)) {
+      updates.verified = formData.verified
     }
 
     // XP & Stats — compare numerically
@@ -202,6 +206,20 @@ function UserEditModal({ user, onSave, onClose, isSaving }) {
                   <span>{formData.isAdmin ? 'Admin' : 'Not Admin'}</span>
                 </label>
               )}
+            </div>
+
+            {/* Editable: Verified toggle */}
+            <div className="user-modal-field">
+              <label className="user-modal-label">Verified Status</label>
+              <label className="user-modal-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={formData.verified}
+                  onChange={(e) => handleChange('verified', e.target.checked)}
+                  disabled={isSaving}
+                />
+                <span>{formData.verified ? 'Verified' : 'Not Verified'}</span>
+              </label>
             </div>
           </div>
 

--- a/react-vite-app/src/services/userService.js
+++ b/react-vite-app/src/services/userService.js
@@ -15,6 +15,7 @@ export async function createUserDoc(uid, email, username) {
     email,
     username,
     isAdmin,
+    verified: false,
     totalXp: 0,
     gamesPlayed: 0,
     createdAt: serverTimestamp()


### PR DESCRIPTION
## Summary
- Added a **Verified** column with color-coded badges (blue for verified, gray for unverified) to the Manage Accounts table
- Added a **Verified Status** toggle checkbox in the Edit User modal under the Permissions section
- Added `verified: false` as a default field for new user documents in Firestore

## Test plan
- [ ] Open Admin Panel → Manage Accounts tab and confirm the "Verified" column appears between Admin and Status
- [ ] Verify badges display "Yes" (blue) or "No" (gray) correctly for each account
- [ ] Click Edit on a user → confirm "Verified Status" toggle appears in the Permissions section
- [ ] Toggle verified on and save → confirm the table updates to show "Yes" with a blue badge
- [ ] Toggle verified off and save → confirm it reverts to "No" with a gray badge
- [ ] Confirm no changes are submitted when the modal is closed without modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)