### PR TITLE
Add GeoGuessr Duels-style 1v1 multiplayer mode

### DIFF
--- a/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.css
+++ b/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.css
@@ -1,0 +1,483 @@
+.duel-final-screen {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.duel-final-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.duel-final-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 30% 20%, rgba(108, 181, 45, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 70% 80%, rgba(231, 76, 60, 0.1) 0%, transparent 40%);
+}
+
+.duel-final-confetti-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* Reuse confetti animation from FinalResultsScreen */
+.duel-final-screen .confetti {
+  position: absolute;
+  top: -20px;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  animation: confettiFall 4s ease-in-out infinite;
+}
+
+@keyframes confettiFall {
+  0% { transform: translateY(0) rotate(0deg); opacity: 1; }
+  100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }
+}
+
+/* ── Content ── */
+.duel-final-content {
+  position: relative;
+  z-index: 1;
+  max-width: 750px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* ── Hero ── */
+.duel-final-hero {
+  text-align: center;
+  padding-top: 1rem;
+}
+
+.duel-final-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  margin-bottom: 1.5rem;
+  animation: badgePop 0.6s ease-out;
+}
+
+.duel-final-badge.victory {
+  background: linear-gradient(135deg, #ffd700 0%, #ffaa00 100%);
+  box-shadow: 0 0 50px rgba(255, 215, 0, 0.6);
+}
+
+.duel-final-badge.defeat {
+  background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+  box-shadow: 0 0 50px rgba(231, 76, 60, 0.5);
+}
+
+@keyframes badgePop {
+  0% { transform: scale(0); opacity: 0; }
+  50% { transform: scale(1.2); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.duel-final-badge-emoji {
+  font-size: 3.5rem;
+}
+
+.duel-final-title {
+  font-size: 3rem;
+  font-weight: 900;
+  margin-bottom: 0.5rem;
+}
+
+.duel-final-title.victory {
+  color: #ffd700;
+  text-shadow: 0 0 30px rgba(255, 215, 0, 0.5);
+}
+
+.duel-final-title.defeat {
+  color: #e74c3c;
+  text-shadow: 0 0 30px rgba(231, 76, 60, 0.5);
+}
+
+.duel-final-subtitle {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+/* ── Score Summary Cards ── */
+.duel-final-summary {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.duel-final-player-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1.5rem 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-card);
+  position: relative;
+}
+
+.duel-final-player-card.winner-card {
+  border-color: rgba(108, 181, 45, 0.4);
+  background: linear-gradient(135deg, rgba(108, 181, 45, 0.08) 0%, var(--bg-card) 100%);
+}
+
+.duel-final-player-card.loser-card {
+  border-color: rgba(231, 76, 60, 0.3);
+  background: linear-gradient(135deg, rgba(231, 76, 60, 0.05) 0%, var(--bg-card) 100%);
+}
+
+.duel-final-card-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #ffd700;
+  min-height: 1.2em;
+}
+
+.duel-final-card-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.duel-final-card-score {
+  font-size: 2.2rem;
+  font-weight: 900;
+  color: var(--accent-green);
+  text-shadow: 0 0 20px rgba(108, 181, 45, 0.4);
+}
+
+.loser-card .duel-final-card-score {
+  color: var(--text-muted);
+  text-shadow: none;
+}
+
+.duel-final-card-sub {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.duel-final-card-health {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.duel-final-card-health-bar {
+  width: 100%;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.duel-final-card-health-fill {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 1.5s ease-out;
+}
+
+.duel-final-card-health-fill.green {
+  background: linear-gradient(90deg, #4a9c20 0%, #6cb52d 100%);
+  box-shadow: 0 0 6px rgba(108, 181, 45, 0.3);
+}
+
+.duel-final-card-health-fill.red {
+  background: linear-gradient(90deg, #c0392b 0%, #e74c3c 100%);
+  box-shadow: 0 0 6px rgba(231, 76, 60, 0.3);
+}
+
+.duel-final-card-health-value {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.duel-final-vs {
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  font-weight: 900;
+  color: var(--text-muted);
+  padding: 0 0.25rem;
+}
+
+/* ── Round History ── */
+.duel-final-history {
+  background-color: var(--bg-card);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+}
+
+.duel-final-history-title {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.duel-final-rounds-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.duel-final-round-item {
+  padding: 0.75rem;
+  background-color: var(--bg-secondary);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.duel-final-round-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.duel-final-round-num {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.duel-final-round-mult {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #ffc107;
+  padding: 0.15rem 0.5rem;
+  background: rgba(255, 193, 7, 0.1);
+  border-radius: 10px;
+}
+
+.duel-final-round-scores {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.duel-final-round-player {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.duel-final-round-player:last-of-type {
+  justify-content: flex-end;
+}
+
+.duel-frp-name {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.duel-frp-score {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.duel-final-round-player.round-winner .duel-frp-score {
+  color: var(--accent-green);
+}
+
+.duel-final-round-vs {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.duel-final-round-damage {
+  text-align: center;
+}
+
+.duel-frd-text {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #e74c3c;
+}
+
+.duel-frd-tie {
+  color: var(--text-muted);
+}
+
+.duel-final-round-health {
+  display: flex;
+  gap: 1rem;
+}
+
+.duel-frh-bar-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.duel-frh-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.duel-frh-fill {
+  height: 100%;
+  border-radius: 3px;
+}
+
+.duel-frh-fill.green {
+  background: #6cb52d;
+}
+
+.duel-frh-fill.red {
+  background: #e74c3c;
+}
+
+.duel-frh-val {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  min-width: 40px;
+  text-align: right;
+}
+
+/* ── Action Buttons ── */
+.duel-final-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  padding-bottom: 1rem;
+}
+
+.duel-final-play-again,
+.duel-final-home {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.duel-final-play-again {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  border: none;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+}
+
+.duel-final-play-again:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.duel-final-home {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 2px solid var(--border-color);
+}
+
+.duel-final-home:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.duel-final-actions .button-icon {
+  font-size: 1.2rem;
+}
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  .duel-final-screen {
+    padding: 1rem;
+  }
+
+  .duel-final-title {
+    font-size: 2.2rem;
+  }
+
+  .duel-final-badge {
+    width: 80px;
+    height: 80px;
+  }
+
+  .duel-final-badge-emoji {
+    font-size: 2.5rem;
+  }
+
+  .duel-final-summary {
+    flex-direction: column;
+  }
+
+  .duel-final-vs {
+    justify-content: center;
+  }
+
+  .duel-final-card-score {
+    font-size: 1.8rem;
+  }
+
+  .duel-final-actions {
+    flex-direction: column;
+  }
+
+  .duel-final-play-again,
+  .duel-final-home {
+    width: 100%;
+  }
+
+  .duel-final-round-scores {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .duel-final-round-player:last-of-type {
+    justify-content: flex-start;
+  }
+}

--- a/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.jsx
+++ b/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.jsx
@@ -1,0 +1,233 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { STARTING_HEALTH } from '../../services/duelService';
+import './DuelFinalScreen.css';
+
+const CONFETTI_COLORS = ['#6cb52d', '#ffc107', '#ff4757', '#3498db', '#9b59b6', '#e74c3c'];
+
+function generateConfettiData(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    left: `${Math.random() * 100}%`,
+    delay: `${Math.random() * 2}s`,
+    color: CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)]
+  }));
+}
+
+function DuelFinalScreen({
+  winner,
+  loser,
+  myUid,
+  players,
+  roundHistory,
+  health,
+  onPlayAgain,
+  onBackToTitle
+}) {
+  const [animationComplete, setAnimationComplete] = useState(false);
+
+  const confettiPieces = useMemo(() => generateConfettiData(40), []);
+
+  const isWinner = winner === myUid;
+  const winnerPlayer = players.find(p => p.uid === winner);
+  const loserPlayer = players.find(p => p.uid === loser);
+  const winnerUsername = winnerPlayer?.username || 'Winner';
+  const loserUsername = loserPlayer?.username || 'Loser';
+
+  // My opponent
+  const opponent = players.find(p => p.uid !== myUid);
+  const opponentUid = opponent?.uid || null;
+  const myUsername = players.find(p => p.uid === myUid)?.username || 'You';
+  const opponentUsername = opponent?.username || 'Opponent';
+
+  // Calculate total scores
+  const totalRounds = roundHistory.length;
+  const myTotalScore = roundHistory.reduce((sum, r) => sum + (r.players?.[myUid]?.score || 0), 0);
+  const opTotalScore = roundHistory.reduce((sum, r) => sum + (r.players?.[opponentUid]?.score || 0), 0);
+
+  // Final health
+  const myFinalHealth = health?.[myUid] ?? 0;
+  const opFinalHealth = health?.[opponentUid] ?? 0;
+
+  // Spacebar to play again
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      onPlayAgain();
+    }
+  }, [onPlayAgain]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Trigger animations
+  useEffect(() => {
+    const timer = setTimeout(() => setAnimationComplete(true), 1500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="duel-final-screen">
+      <div className="duel-final-background">
+        <div className="duel-final-confetti-container">
+          {animationComplete && isWinner && confettiPieces.map((piece) => (
+            <div
+              key={piece.id}
+              className="confetti"
+              style={{
+                left: piece.left,
+                animationDelay: piece.delay,
+                backgroundColor: piece.color
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="duel-final-content">
+        {/* Hero */}
+        <div className="duel-final-hero">
+          <div className={`duel-final-badge ${isWinner ? 'victory' : 'defeat'}`}>
+            <span className="duel-final-badge-emoji">
+              {isWinner ? '🏆' : '💀'}
+            </span>
+          </div>
+          <h1 className={`duel-final-title ${isWinner ? 'victory' : 'defeat'}`}>
+            {isWinner ? 'Victory!' : 'Defeat'}
+          </h1>
+          <p className="duel-final-subtitle">
+            {isWinner
+              ? `You defeated ${loserUsername} in ${totalRounds} rounds!`
+              : `${winnerUsername} won after ${totalRounds} rounds`}
+          </p>
+        </div>
+
+        {/* Score Summary */}
+        <div className="duel-final-summary">
+          <div className={`duel-final-player-card ${isWinner ? 'winner-card' : 'loser-card'}`}>
+            <span className="duel-final-card-label">
+              {isWinner ? '👑 Winner' : ''}
+            </span>
+            <span className="duel-final-card-name">{myUsername}</span>
+            <span className="duel-final-card-score">{myTotalScore.toLocaleString()}</span>
+            <span className="duel-final-card-sub">Total Points</span>
+            <div className="duel-final-card-health">
+              <div className="duel-final-card-health-bar">
+                <div
+                  className="duel-final-card-health-fill green"
+                  style={{ width: `${(myFinalHealth / STARTING_HEALTH) * 100}%` }}
+                />
+              </div>
+              <span className="duel-final-card-health-value">{myFinalHealth.toLocaleString()} HP</span>
+            </div>
+          </div>
+
+          <div className="duel-final-vs">VS</div>
+
+          <div className={`duel-final-player-card ${!isWinner ? 'winner-card' : 'loser-card'}`}>
+            <span className="duel-final-card-label">
+              {!isWinner ? '👑 Winner' : ''}
+            </span>
+            <span className="duel-final-card-name">{opponentUsername}</span>
+            <span className="duel-final-card-score">{opTotalScore.toLocaleString()}</span>
+            <span className="duel-final-card-sub">Total Points</span>
+            <div className="duel-final-card-health">
+              <div className="duel-final-card-health-bar">
+                <div
+                  className="duel-final-card-health-fill red"
+                  style={{ width: `${(opFinalHealth / STARTING_HEALTH) * 100}%` }}
+                />
+              </div>
+              <span className="duel-final-card-health-value">{opFinalHealth.toLocaleString()} HP</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Round History */}
+        <div className="duel-final-history">
+          <h2 className="duel-final-history-title">Round History</h2>
+          <div className="duel-final-rounds-list">
+            {roundHistory.map((round, index) => {
+              const myRoundData = round.players?.[myUid] || {};
+              const opRoundData = round.players?.[opponentUid] || {};
+              const myRoundScore = myRoundData.score || 0;
+              const opRoundScore = opRoundData.score || 0;
+              const iWonRound = myRoundScore > opRoundScore;
+              const tiedRound = myRoundScore === opRoundScore;
+              const myHealthAfter = round.healthAfter?.[myUid] ?? 0;
+              const opHealthAfter = round.healthAfter?.[opponentUid] ?? 0;
+
+              return (
+                <div key={index} className="duel-final-round-item">
+                  <div className="duel-final-round-header">
+                    <span className="duel-final-round-num">Round {round.roundNumber}</span>
+                    <span className="duel-final-round-mult">{round.multiplier}x</span>
+                  </div>
+
+                  <div className="duel-final-round-scores">
+                    <div className={`duel-final-round-player ${iWonRound && !tiedRound ? 'round-winner' : ''}`}>
+                      <span className="duel-frp-name">{myUsername}</span>
+                      <span className="duel-frp-score">{myRoundScore.toLocaleString()}</span>
+                    </div>
+                    <span className="duel-final-round-vs">vs</span>
+                    <div className={`duel-final-round-player ${!iWonRound && !tiedRound ? 'round-winner' : ''}`}>
+                      <span className="duel-frp-name">{opponentUsername}</span>
+                      <span className="duel-frp-score">{opRoundScore.toLocaleString()}</span>
+                    </div>
+                  </div>
+
+                  <div className="duel-final-round-damage">
+                    {round.damage > 0 ? (
+                      <span className="duel-frd-text">
+                        -{round.damage.toLocaleString()} HP to{' '}
+                        {round.damagedPlayer === myUid ? myUsername : opponentUsername}
+                      </span>
+                    ) : (
+                      <span className="duel-frd-text duel-frd-tie">Tie - No damage</span>
+                    )}
+                  </div>
+
+                  <div className="duel-final-round-health">
+                    <div className="duel-frh-bar-wrapper">
+                      <div className="duel-frh-bar">
+                        <div
+                          className="duel-frh-fill green"
+                          style={{ width: `${(myHealthAfter / STARTING_HEALTH) * 100}%` }}
+                        />
+                      </div>
+                      <span className="duel-frh-val">{myHealthAfter.toLocaleString()}</span>
+                    </div>
+                    <div className="duel-frh-bar-wrapper">
+                      <div className="duel-frh-bar">
+                        <div
+                          className="duel-frh-fill red"
+                          style={{ width: `${(opHealthAfter / STARTING_HEALTH) * 100}%` }}
+                        />
+                      </div>
+                      <span className="duel-frh-val">{opHealthAfter.toLocaleString()}</span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="duel-final-actions">
+          <button className="duel-final-play-again" onClick={onPlayAgain}>
+            <span className="button-icon">🔄</span>
+            Play Again
+          </button>
+          <button className="duel-final-home" onClick={onBackToTitle}>
+            <span className="button-icon">🏠</span>
+            Back to Home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DuelFinalScreen;

--- a/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.css
+++ b/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.css
@@ -1,0 +1,272 @@
+.duel-game-screen {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--bg-dark);
+}
+
+/* ── Health Bars ── */
+.duel-health-bar-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(180deg, rgba(15, 15, 35, 0.95) 0%, rgba(12, 12, 15, 0.9) 100%);
+  border-bottom: 1px solid var(--border-color);
+  z-index: 10;
+}
+
+.duel-health-player {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.duel-health-left {
+  flex-direction: row;
+}
+
+.duel-health-right {
+  flex-direction: row-reverse;
+}
+
+.duel-health-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  min-width: 80px;
+}
+
+.duel-health-left .duel-health-name {
+  text-align: left;
+}
+
+.duel-health-right .duel-health-name {
+  text-align: right;
+}
+
+.duel-health-bar {
+  flex: 1;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 7px;
+  overflow: hidden;
+  position: relative;
+}
+
+.duel-health-fill {
+  height: 100%;
+  border-radius: 7px;
+  transition: width 0.8s ease-out;
+  position: relative;
+}
+
+.duel-health-fill-green {
+  background: linear-gradient(90deg, #4a9c20 0%, #6cb52d 100%);
+  box-shadow: 0 0 8px rgba(108, 181, 45, 0.4);
+}
+
+.duel-health-fill-red {
+  background: linear-gradient(90deg, #c0392b 0%, #e74c3c 100%);
+  box-shadow: 0 0 8px rgba(231, 76, 60, 0.4);
+}
+
+.duel-health-fill.critical {
+  animation: healthPulse 1s ease-in-out infinite;
+}
+
+@keyframes healthPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+.duel-health-value {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  min-width: 50px;
+  text-align: center;
+}
+
+.duel-round-badge-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  padding: 0.3rem 1rem;
+  background: rgba(108, 181, 45, 0.1);
+  border: 1px solid rgba(108, 181, 45, 0.3);
+  border-radius: 12px;
+  min-width: 60px;
+}
+
+.duel-round-label {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+}
+
+.duel-round-number {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--accent-green);
+}
+
+/* ── Main Game Layout ── */
+.duel-game-main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.duel-game-main .image-panel {
+  flex: 7;
+  display: flex;
+  background-color: var(--bg-dark);
+  border-right: 1px solid var(--border-color);
+}
+
+.duel-game-main .guess-panel {
+  flex: 3;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg-panel);
+  min-width: 320px;
+  max-width: 400px;
+  position: relative;
+}
+
+/* ── Waiting Overlay ── */
+.duel-waiting-overlay {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.duel-waiting-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+}
+
+.duel-waiting-icon {
+  font-size: 3rem;
+  animation: waitingPulse 2s ease-in-out infinite;
+}
+
+@keyframes waitingPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.1); opacity: 0.7; }
+}
+
+.duel-waiting-text {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.duel-waiting-sub {
+  font-size: 0.85rem;
+  color: var(--accent-green);
+  font-weight: 500;
+}
+
+.duel-waiting-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.duel-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--accent-green);
+  border-radius: 50%;
+  animation: duelDotBounce 1.4s ease-in-out infinite;
+}
+
+.duel-dot:nth-child(1) { animation-delay: 0s; }
+.duel-dot:nth-child(2) { animation-delay: 0.2s; }
+.duel-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes duelDotBounce {
+  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-6px); }
+}
+
+/* ── Opponent guessed indicator ── */
+.duel-opponent-guessed {
+  padding: 0.6rem 1rem;
+  margin: 0 1rem 1rem;
+  background: rgba(108, 181, 45, 0.1);
+  border: 1px solid rgba(108, 181, 45, 0.3);
+  border-radius: 8px;
+  color: var(--accent-green);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: center;
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Responsive ── */
+@media (max-width: 1024px) {
+  .duel-game-main {
+    flex-direction: column;
+  }
+
+  .duel-game-main .image-panel {
+    flex: none;
+    height: 45vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .duel-game-main .guess-panel {
+    flex: 1;
+    min-width: 100%;
+    max-width: 100%;
+  }
+
+  .duel-health-bar-container {
+    padding: 0.5rem 1rem;
+    gap: 0.5rem;
+  }
+
+  .duel-health-name {
+    font-size: 0.75rem;
+    min-width: 60px;
+  }
+}
+
+@media (max-width: 600px) {
+  .duel-health-bar-container {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .duel-health-player {
+    flex: 1 1 40%;
+  }
+
+  .duel-round-badge-center {
+    order: -1;
+    flex: 0 0 100%;
+    flex-direction: row;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-bottom: 0.25rem;
+  }
+}

--- a/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
+++ b/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
@@ -1,0 +1,212 @@
+import { useEffect, useCallback } from 'react';
+import ImageViewer from '../ImageViewer/ImageViewer';
+import MapPicker from '../MapPicker/MapPicker';
+import FloorSelector from '../FloorSelector/FloorSelector';
+import GuessButton from '../GuessButton/GuessButton';
+import { STARTING_HEALTH } from '../../services/duelService';
+import './DuelGameScreen.css';
+
+function DuelGameScreen({
+  imageUrl,
+  guessLocation,
+  guessFloor,
+  availableFloors,
+  onMapClick,
+  onFloorSelect,
+  onSubmitGuess,
+  onBackToTitle,
+  currentRound,
+  clickRejected = false,
+  playingArea = null,
+  timeRemaining,
+  timeLimitSeconds = 20,
+  hasSubmitted = false,
+  opponentHasSubmitted = false,
+  opponentUsername = 'Opponent',
+  myHealth,
+  opponentHealth,
+  myUsername = 'You'
+}) {
+  const isInRegion = availableFloors !== null && availableFloors.length > 0;
+  const canSubmit = !hasSubmitted && guessLocation !== null && (!isInRegion || guessFloor !== null);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space' && canSubmit) {
+      e.preventDefault();
+      onSubmitGuess();
+    }
+  }, [canSubmit, onSubmitGuess]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const myHealthPct = Math.max(0, (myHealth / STARTING_HEALTH) * 100);
+  const opponentHealthPct = Math.max(0, (opponentHealth / STARTING_HEALTH) * 100);
+
+  return (
+    <div className="duel-game-screen">
+      {/* Health Bars at Top */}
+      <div className="duel-health-bar-container">
+        <div className="duel-health-player duel-health-left">
+          <span className="duel-health-name">{myUsername} (You)</span>
+          <div className="duel-health-bar">
+            <div
+              className={`duel-health-fill duel-health-fill-green ${myHealthPct <= 25 ? 'critical' : ''}`}
+              style={{ width: `${myHealthPct}%` }}
+            />
+          </div>
+          <span className="duel-health-value">{myHealth.toLocaleString()}</span>
+        </div>
+
+        <div className="duel-round-badge-center">
+          <span className="duel-round-label">Round</span>
+          <span className="duel-round-number">{currentRound}</span>
+        </div>
+
+        <div className="duel-health-player duel-health-right">
+          <span className="duel-health-name">{opponentUsername}</span>
+          <div className="duel-health-bar">
+            <div
+              className={`duel-health-fill duel-health-fill-red ${opponentHealthPct <= 25 ? 'critical' : ''}`}
+              style={{ width: `${opponentHealthPct}%` }}
+            />
+          </div>
+          <span className="duel-health-value">{opponentHealth.toLocaleString()}</span>
+        </div>
+      </div>
+
+      {/* Main Game Layout */}
+      <div className="duel-game-main">
+        {/* Left panel - Image */}
+        <div className="image-panel">
+          <ImageViewer imageUrl={imageUrl} />
+        </div>
+
+        {/* Right panel - Guess controls */}
+        <div className="guess-panel">
+          <div className="guess-panel-header">
+            <button className="back-button" onClick={onBackToTitle}>
+              <span>&larr;</span>
+              <span>Quit</span>
+            </button>
+            <h2 className="panel-title">Make Your Guess</h2>
+          </div>
+
+          {typeof timeRemaining === 'number' && (
+            <div className="round-timer">
+              <div className="round-timer-top">
+                <span className="timer-label">
+                  Time left ({timeLimitSeconds}s)
+                </span>
+                <span
+                  className={
+                    `timer-value${
+                      timeRemaining <= 5
+                        ? ' critical'
+                        : timeRemaining <= 10
+                          ? ' warning'
+                          : ''
+                    }`
+                  }
+                >
+                  {timeRemaining.toFixed(2)}s
+                </span>
+              </div>
+              <div className="timer-bar">
+                <div
+                  className={
+                    `timer-bar-fill${
+                      timeRemaining <= 5
+                        ? ' critical'
+                        : timeRemaining <= 10
+                          ? ' warning'
+                          : ''
+                    }`
+                  }
+                  style={{
+                    width: `${Math.max(0, Math.min(1, timeRemaining / timeLimitSeconds)) * 100}%`
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Waiting overlay */}
+          {hasSubmitted && (
+            <div className="duel-waiting-overlay">
+              <div className="duel-waiting-content">
+                <div className="duel-waiting-icon">
+                  {opponentHasSubmitted ? '✓' : '⏳'}
+                </div>
+                <p className="duel-waiting-text">
+                  {opponentHasSubmitted
+                    ? 'Both guesses in! Processing...'
+                    : 'Waiting for opponent...'}
+                </p>
+                <div className="duel-waiting-dots">
+                  <span className="duel-dot"></span>
+                  <span className="duel-dot"></span>
+                  <span className="duel-dot"></span>
+                </div>
+                {opponentHasSubmitted && (
+                  <p className="duel-waiting-sub">{opponentUsername} has guessed</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {!hasSubmitted && (
+            <div className="guess-controls">
+              <MapPicker
+                markerPosition={guessLocation}
+                onMapClick={onMapClick}
+                clickRejected={clickRejected}
+                playingArea={playingArea}
+              />
+
+              {isInRegion && (
+                <FloorSelector
+                  selectedFloor={guessFloor}
+                  onFloorSelect={onFloorSelect}
+                  floors={availableFloors}
+                />
+              )}
+
+              <GuessButton
+                disabled={!canSubmit}
+                onClick={onSubmitGuess}
+              />
+            </div>
+          )}
+
+          {/* Guess Status */}
+          {!hasSubmitted && (
+            <div className="guess-status">
+              <div className={`status-item ${guessLocation ? 'complete' : ''}`}>
+                <span className="status-icon">{guessLocation ? '\u2713' : '\u25CB'}</span>
+                <span>Location selected</span>
+              </div>
+              {isInRegion && (
+                <div className={`status-item ${guessFloor ? 'complete' : ''}`}>
+                  <span className="status-icon">{guessFloor ? '\u2713' : '\u25CB'}</span>
+                  <span>Floor selected</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Opponent status indicator */}
+          {!hasSubmitted && opponentHasSubmitted && (
+            <div className="duel-opponent-guessed">
+              {opponentUsername} has made their guess!
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DuelGameScreen;

--- a/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.css
+++ b/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.css
@@ -1,0 +1,551 @@
+.duel-result-screen {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 100%);
+  padding: 1.5rem;
+}
+
+/* ── Header ── */
+.duel-result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.duel-result-round {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.duel-result-multiplier {
+  padding: 0.35rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #ffc107;
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+}
+
+/* ── Main Content ── */
+.duel-result-content {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  flex: 1;
+}
+
+/* ── Map ── */
+.duel-result-map-container {
+  background-color: var(--bg-card);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.duel-result-map {
+  position: relative;
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  background-color: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.duel-result-map .map-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.duel-result-zoom-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  will-change: transform;
+  transform-origin: 0 0;
+}
+
+/* ── Markers ── */
+.duel-pin-red {
+  background: linear-gradient(135deg, #ff4757 0%, #ff6b81 100%);
+  box-shadow: 0 4px 12px rgba(255, 71, 87, 0.5);
+}
+
+.duel-pin-blue {
+  background: linear-gradient(135deg, #3498db 0%, #74b9ff 100%);
+  box-shadow: 0 4px 12px rgba(52, 152, 219, 0.5);
+}
+
+/* Reuse result-marker, marker-pin, actual-pin, marker-label from ResultScreen */
+.duel-result-screen .result-marker {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.duel-result-screen .marker-pin {
+  width: 28px;
+  height: 28px;
+  border-radius: 50% 50% 50% 0;
+  transform: rotate(-45deg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border: 3px solid white;
+  animation: duelMarkerDrop 0.5s ease-out;
+}
+
+.duel-result-screen .marker-pin::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 10px;
+  height: 10px;
+  background-color: white;
+  border-radius: 50%;
+}
+
+.duel-result-screen .actual-pin {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-light, #7dd33a) 100%);
+  box-shadow: 0 4px 12px rgba(108, 181, 45, 0.5);
+}
+
+.duel-result-screen .marker-label {
+  margin-top: 8px;
+  padding: 4px 10px;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: white;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+@keyframes duelMarkerDrop {
+  0% { opacity: 0; transform: rotate(-45deg) scale(0.5) translateY(-30px); }
+  60% { transform: rotate(-45deg) scale(1.1); }
+  100% { opacity: 1; transform: rotate(-45deg) scale(1); }
+}
+
+/* ── Lines ── */
+.duel-result-line {
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: drawLine 0.8s ease-out forwards;
+}
+
+.duel-result-line-delayed {
+  animation-delay: 0.2s;
+}
+
+@keyframes drawLine {
+  to { stroke-dashoffset: 0; }
+}
+
+/* ── Zoom controls (reuse from ResultScreen) ── */
+.duel-result-map .zoom-controls {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 20;
+}
+
+.duel-result-map .zoom-btn {
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+  line-height: 1;
+}
+
+.duel-result-map .zoom-btn:hover:not(:disabled) {
+  background-color: rgba(0, 0, 0, 0.9);
+}
+
+.duel-result-map .zoom-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.duel-result-map .zoom-indicator {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 8px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 6px;
+  z-index: 20;
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+}
+
+/* ── Details Panel ── */
+.duel-result-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.duel-result-image-preview {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  aspect-ratio: 16 / 9;
+}
+
+.duel-result-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ── Score Comparison ── */
+.duel-score-comparison {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background-color: var(--bg-card);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.4s ease-out;
+}
+
+.duel-score-comparison.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.duel-score-player {
+  flex: 1;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.duel-score-player.winner {
+  position: relative;
+}
+
+.duel-score-player.winner::after {
+  content: '👑';
+  position: absolute;
+  top: -8px;
+  right: 4px;
+  font-size: 0.9rem;
+}
+
+.duel-score-name {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.duel-score-value {
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: var(--text-primary);
+}
+
+.duel-score-player.winner .duel-score-value {
+  color: var(--accent-green);
+  text-shadow: 0 0 15px rgba(108, 181, 45, 0.4);
+}
+
+.duel-score-player.loser .duel-score-value {
+  color: var(--text-muted);
+}
+
+.duel-score-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.duel-score-vs {
+  font-size: 0.8rem;
+  font-weight: 800;
+  color: var(--text-muted);
+  padding: 0.3rem 0.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+}
+
+/* ── Damage Display ── */
+.duel-damage-display {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(231, 76, 60, 0.1);
+  border: 1px solid rgba(231, 76, 60, 0.3);
+  animation: damageSlide 0.4s ease-out;
+}
+
+.duel-damage-display.duel-damage-tie {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--border-color);
+}
+
+@keyframes damageSlide {
+  from { opacity: 0; transform: translateX(-10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.duel-damage-icon {
+  font-size: 1.5rem;
+}
+
+.duel-damage-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.duel-damage-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #e74c3c;
+}
+
+.duel-damage-tie .duel-damage-value {
+  color: var(--text-secondary);
+}
+
+.duel-damage-target {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.duel-damage-mult {
+  font-size: 0.75rem;
+  color: #ffc107;
+  font-weight: 600;
+}
+
+/* ── Health Bars ── */
+.duel-result-health {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background-color: var(--bg-card);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+}
+
+.duel-result-health-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.duel-rh-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  min-width: 80px;
+}
+
+.duel-rh-bar {
+  flex: 1;
+  height: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.duel-rh-fill {
+  height: 100%;
+  border-radius: 6px;
+}
+
+.duel-rh-fill.animated {
+  transition: width 1s ease-out;
+}
+
+.duel-rh-fill-green {
+  background: linear-gradient(90deg, #4a9c20 0%, #6cb52d 100%);
+  box-shadow: 0 0 6px rgba(108, 181, 45, 0.3);
+}
+
+.duel-rh-fill-red {
+  background: linear-gradient(90deg, #c0392b 0%, #e74c3c 100%);
+  box-shadow: 0 0 6px rgba(231, 76, 60, 0.3);
+}
+
+.duel-rh-value {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  min-width: 45px;
+  text-align: right;
+}
+
+/* ── KO Banner ── */
+.duel-ko-banner {
+  text-align: center;
+  padding: 0.75rem;
+  animation: koPulse 0.6s ease-out;
+}
+
+.duel-ko-text {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: #e74c3c;
+  text-shadow: 0 0 30px rgba(231, 76, 60, 0.6),
+               0 0 60px rgba(231, 76, 60, 0.3);
+  letter-spacing: 4px;
+}
+
+@keyframes koPulse {
+  0% { transform: scale(0.3); opacity: 0; }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+/* ── Action Button ── */
+.duel-result-action-btn {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: var(--text-primary);
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 20px rgba(108, 181, 45, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.duel-result-action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(108, 181, 45, 0.5);
+}
+
+.duel-result-action-btn .button-arrow {
+  font-size: 1.3rem;
+  transition: transform 0.2s ease;
+}
+
+.duel-result-action-btn:hover .button-arrow {
+  transform: translateX(4px);
+}
+
+/* ── Waiting for host ── */
+.duel-result-waiting-host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.duel-result-waiting-host .duel-waiting-dots {
+  display: flex;
+  gap: 6px;
+}
+
+.duel-result-waiting-host .duel-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  animation: duelDotBounce 1.4s ease-in-out infinite;
+}
+
+.duel-result-waiting-host .duel-dot:nth-child(1) { animation-delay: 0s; }
+.duel-result-waiting-host .duel-dot:nth-child(2) { animation-delay: 0.2s; }
+.duel-result-waiting-host .duel-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes duelDotBounce {
+  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-4px); }
+}
+
+/* ── Responsive ── */
+@media (max-width: 900px) {
+  .duel-result-content {
+    grid-template-columns: 1fr;
+  }
+
+  .duel-result-map-container {
+    height: auto !important;
+  }
+
+  .duel-result-map {
+    min-height: 300px;
+  }
+
+  .duel-score-value {
+    font-size: 1.4rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .duel-result-screen {
+    padding: 1rem;
+  }
+
+  .duel-result-header {
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .duel-result-map {
+    min-height: 250px;
+  }
+
+  .duel-score-value {
+    font-size: 1.2rem;
+  }
+
+  .duel-ko-text {
+    font-size: 2rem;
+  }
+}

--- a/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.jsx
+++ b/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.jsx
@@ -1,0 +1,346 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+import useMapZoom from '../../hooks/useMapZoom';
+import { STARTING_HEALTH } from '../../services/duelService';
+import './DuelResultScreen.css';
+
+/**
+ * Format distance as a readable string
+ */
+function formatDistance(distance) {
+  if (distance === null || distance === undefined) return 'No guess';
+  const feet = Math.round(distance * 2);
+  if (feet <= 10) return 'Perfect!';
+  return `${feet} ft away`;
+}
+
+function DuelResultScreen({
+  roundNumber,
+  imageUrl,
+  actualLocation,
+  myGuess,
+  opponentGuess,
+  myUsername,
+  opponentUsername,
+  myHealth,
+  opponentHealth,
+  myHealthBefore,
+  opponentHealthBefore,
+  damage,
+  multiplier,
+  damagedPlayer,
+  myUid,
+  isHost,
+  onNextRound,
+  onViewFinalResults,
+  isGameOver
+}) {
+  const mapContainerRef = useRef(null);
+  const detailsRef = useRef(null);
+  const mapOuterRef = useRef(null);
+  const [animationPhase, setAnimationPhase] = useState(0);
+  const [displayedMyScore, setDisplayedMyScore] = useState(0);
+  const [displayedOpScore, setDisplayedOpScore] = useState(0);
+
+  const myScore = myGuess?.score ?? 0;
+  const opScore = opponentGuess?.score ?? 0;
+
+  const myLocation = myGuess?.location || null;
+  const opLocation = opponentGuess?.location || null;
+
+  const iWon = myScore > opScore;
+  const iLost = myScore < opScore;
+  const isTie = myScore === opScore;
+  const iTookDamage = damagedPlayer === myUid;
+
+  // Sync map container height to details panel
+  useEffect(() => {
+    const detailsEl = detailsRef.current;
+    const mapEl = mapOuterRef.current;
+    if (!detailsEl || !mapEl) return;
+
+    const syncHeight = () => {
+      const detailsHeight = detailsEl.offsetHeight;
+      if (detailsHeight > 0) {
+        mapEl.style.height = `${detailsHeight}px`;
+      }
+    };
+
+    syncHeight();
+    const observer = new ResizeObserver(syncHeight);
+    observer.observe(detailsEl);
+    return () => observer.disconnect();
+  }, []);
+
+  const { scale, transformStyle, zoomIn, zoomOut, resetZoom } = useMapZoom(mapContainerRef);
+  const isZoomed = scale > 1;
+
+  // Animation sequence
+  useEffect(() => {
+    const timers = [
+      setTimeout(() => setAnimationPhase(1), 300),
+      setTimeout(() => setAnimationPhase(2), 700),
+      setTimeout(() => setAnimationPhase(3), 1100),
+      setTimeout(() => setAnimationPhase(4), 1500),
+    ];
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  // Spacebar to advance
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (isGameOver) {
+        onViewFinalResults();
+      } else if (isHost) {
+        onNextRound();
+      }
+    }
+  }, [isGameOver, isHost, onNextRound, onViewFinalResults]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Animate score counters
+  useEffect(() => {
+    if (animationPhase >= 3) {
+      const duration = 800;
+      const steps = 25;
+      const myInc = myScore / steps;
+      const opInc = opScore / steps;
+      let currentMy = 0;
+      let currentOp = 0;
+
+      const interval = setInterval(() => {
+        currentMy += myInc;
+        currentOp += opInc;
+
+        if (currentMy >= myScore) setDisplayedMyScore(myScore);
+        else setDisplayedMyScore(Math.round(currentMy));
+
+        if (currentOp >= opScore) setDisplayedOpScore(opScore);
+        else setDisplayedOpScore(Math.round(currentOp));
+
+        if (currentMy >= myScore && currentOp >= opScore) {
+          clearInterval(interval);
+        }
+      }, duration / steps);
+
+      return () => clearInterval(interval);
+    }
+  }, [animationPhase, myScore, opScore]);
+
+  const myHealthPct = Math.max(0, (myHealth / STARTING_HEALTH) * 100);
+  const opHealthPct = Math.max(0, (opponentHealth / STARTING_HEALTH) * 100);
+
+  return (
+    <div className="duel-result-screen">
+      {/* Header */}
+      <div className="duel-result-header">
+        <div className="duel-result-round">
+          Round {roundNumber}
+        </div>
+        <div className="duel-result-multiplier">
+          {multiplier}x Damage
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="duel-result-content">
+        {/* Map */}
+        <div className="duel-result-map-container" ref={mapOuterRef}>
+          <div className="duel-result-map" ref={mapContainerRef}>
+            <div className="duel-result-zoom-content" style={{ transform: transformStyle }}>
+              <img className="map-image" src="/FINAL_MAP.png" alt="Campus Map" />
+
+              {/* Lines from guesses to actual */}
+              {animationPhase >= 2 && (
+                <svg
+                  className="duel-result-line-svg"
+                  style={{
+                    position: 'absolute', top: 0, left: 0,
+                    width: '100%', height: '100%', pointerEvents: 'none'
+                  }}
+                >
+                  {myLocation && (
+                    <line
+                      className="duel-result-line"
+                      x1={`${myLocation.x}%`} y1={`${myLocation.y}%`}
+                      x2={`${actualLocation.x}%`} y2={`${actualLocation.y}%`}
+                      stroke="#ff6b6b" strokeWidth="2" strokeDasharray="6,4"
+                    />
+                  )}
+                  {opLocation && (
+                    <line
+                      className="duel-result-line duel-result-line-delayed"
+                      x1={`${opLocation.x}%`} y1={`${opLocation.y}%`}
+                      x2={`${actualLocation.x}%`} y2={`${actualLocation.y}%`}
+                      stroke="#74b9ff" strokeWidth="2" strokeDasharray="6,4"
+                    />
+                  )}
+                </svg>
+              )}
+
+              {/* My guess marker (red) */}
+              {myLocation && (
+                <div
+                  className="result-marker duel-my-marker"
+                  style={{ left: `${myLocation.x}%`, top: `${myLocation.y}%` }}
+                >
+                  <div className="marker-pin duel-pin-red"></div>
+                  <div className="marker-label">{myUsername}</div>
+                </div>
+              )}
+
+              {/* Opponent guess marker (blue) - Phase 1+ */}
+              {opLocation && animationPhase >= 1 && (
+                <div
+                  className="result-marker duel-opponent-marker"
+                  style={{ left: `${opLocation.x}%`, top: `${opLocation.y}%` }}
+                >
+                  <div className="marker-pin duel-pin-blue"></div>
+                  <div className="marker-label">{opponentUsername}</div>
+                </div>
+              )}
+
+              {/* Actual location marker (green) - Phase 1+ */}
+              {animationPhase >= 1 && (
+                <div
+                  className="result-marker actual-marker"
+                  style={{ left: `${actualLocation.x}%`, top: `${actualLocation.y}%` }}
+                >
+                  <div className="marker-pin actual-pin"></div>
+                  <div className="marker-label">Correct</div>
+                </div>
+              )}
+            </div>
+
+            {/* Zoom controls */}
+            <div className="zoom-controls">
+              <button className="zoom-btn zoom-in-btn" onClick={(e) => { e.stopPropagation(); zoomIn(); }} title="Zoom in" aria-label="Zoom in">+</button>
+              <button className="zoom-btn zoom-out-btn" onClick={(e) => { e.stopPropagation(); zoomOut(); }} title="Zoom out" aria-label="Zoom out" disabled={!isZoomed}>-</button>
+              <button className="zoom-btn zoom-reset-btn" onClick={(e) => { e.stopPropagation(); resetZoom(); }} title="Reset zoom" aria-label="Reset zoom" disabled={!isZoomed}>&#x21BA;</button>
+            </div>
+
+            {isZoomed && (
+              <div className="zoom-indicator">{Math.round(scale * 100)}%</div>
+            )}
+          </div>
+        </div>
+
+        {/* Details panel */}
+        <div className="duel-result-details" ref={detailsRef}>
+          {/* Image preview */}
+          <div className="duel-result-image-preview">
+            <img src={imageUrl} alt="Location" />
+          </div>
+
+          {/* Score comparison */}
+          <div className={`duel-score-comparison ${animationPhase >= 3 ? 'visible' : ''}`}>
+            <div className={`duel-score-player ${iWon ? 'winner' : iLost ? 'loser' : ''}`}>
+              <span className="duel-score-name">{myUsername}</span>
+              <span className="duel-score-value">{displayedMyScore.toLocaleString()}</span>
+              <span className="duel-score-sub">
+                {myGuess?.noGuess ? 'No guess' : formatDistance(myGuess?.distance)}
+              </span>
+            </div>
+
+            <div className="duel-score-vs">VS</div>
+
+            <div className={`duel-score-player ${!iWon && !isTie ? 'winner' : !iLost && !isTie ? 'loser' : ''}`}>
+              <span className="duel-score-name">{opponentUsername}</span>
+              <span className="duel-score-value">{displayedOpScore.toLocaleString()}</span>
+              <span className="duel-score-sub">
+                {opponentGuess?.noGuess ? 'No guess' : formatDistance(opponentGuess?.distance)}
+              </span>
+            </div>
+          </div>
+
+          {/* Damage display */}
+          {animationPhase >= 4 && damage > 0 && (
+            <div className="duel-damage-display">
+              <div className="duel-damage-icon">
+                {iTookDamage ? '💔' : '⚔️'}
+              </div>
+              <div className="duel-damage-info">
+                <span className="duel-damage-value">-{damage.toLocaleString()} HP</span>
+                <span className="duel-damage-target">
+                  {iTookDamage ? `${myUsername} takes damage` : `${opponentUsername} takes damage`}
+                </span>
+                {multiplier > 1 && (
+                  <span className="duel-damage-mult">{multiplier}x multiplier</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {animationPhase >= 4 && damage === 0 && (
+            <div className="duel-damage-display duel-damage-tie">
+              <div className="duel-damage-icon">🤝</div>
+              <div className="duel-damage-info">
+                <span className="duel-damage-value">Tie!</span>
+                <span className="duel-damage-target">No damage dealt</span>
+              </div>
+            </div>
+          )}
+
+          {/* Health bars */}
+          <div className="duel-result-health">
+            <div className="duel-result-health-row">
+              <span className="duel-rh-name">{myUsername}</span>
+              <div className="duel-rh-bar">
+                <div
+                  className={`duel-rh-fill duel-rh-fill-green ${animationPhase >= 4 ? 'animated' : ''}`}
+                  style={{ width: `${animationPhase >= 4 ? myHealthPct : (myHealthBefore / STARTING_HEALTH) * 100}%` }}
+                />
+              </div>
+              <span className="duel-rh-value">{animationPhase >= 4 ? myHealth.toLocaleString() : myHealthBefore.toLocaleString()}</span>
+            </div>
+            <div className="duel-result-health-row">
+              <span className="duel-rh-name">{opponentUsername}</span>
+              <div className="duel-rh-bar">
+                <div
+                  className={`duel-rh-fill duel-rh-fill-red ${animationPhase >= 4 ? 'animated' : ''}`}
+                  style={{ width: `${animationPhase >= 4 ? opHealthPct : (opponentHealthBefore / STARTING_HEALTH) * 100}%` }}
+                />
+              </div>
+              <span className="duel-rh-value">{animationPhase >= 4 ? opponentHealth.toLocaleString() : opponentHealthBefore.toLocaleString()}</span>
+            </div>
+          </div>
+
+          {/* KO indicator */}
+          {isGameOver && animationPhase >= 4 && (
+            <div className="duel-ko-banner">
+              <span className="duel-ko-text">K.O.!</span>
+            </div>
+          )}
+
+          {/* Action button */}
+          {isGameOver ? (
+            <button className="duel-result-action-btn" onClick={onViewFinalResults}>
+              View Final Results
+              <span className="button-arrow">&rarr;</span>
+            </button>
+          ) : isHost ? (
+            <button className="duel-result-action-btn" onClick={onNextRound}>
+              Next Round
+              <span className="button-arrow">&rarr;</span>
+            </button>
+          ) : (
+            <div className="duel-result-waiting-host">
+              <span>Waiting for host to start next round</span>
+              <div className="duel-waiting-dots">
+                <span className="duel-dot"></span>
+                <span className="duel-dot"></span>
+                <span className="duel-dot"></span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DuelResultScreen;

--- a/react-vite-app/src/components/WaitingRoom/WaitingRoom.css
+++ b/react-vite-app/src/components/WaitingRoom/WaitingRoom.css
@@ -342,6 +342,33 @@
   }
 }
 
+/* Ready State */
+.waiting-ready-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1.2rem;
+}
+
+.waiting-ready-text {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--accent-green);
+  text-shadow: 0 0 10px rgba(108, 181, 45, 0.3);
+  animation: readyPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes readyPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* Mode Badge */
+.waiting-badge-mode {
+  border-color: rgba(231, 76, 60, 0.3);
+  color: #e74c3c;
+}
+
 /* Actions */
 .waiting-actions {
   display: flex;

--- a/react-vite-app/src/hooks/useDuelGame.js
+++ b/react-vite-app/src/hooks/useDuelGame.js
@@ -1,0 +1,377 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { getRegions, getFloorsForPoint, getPlayingArea, isPointInPlayingArea } from '../services/regionService';
+import {
+  subscribeDuel,
+  submitDuelGuess,
+  processRound,
+  advanceToNextRound,
+  DUEL_ROUND_TIME_SECONDS,
+  STARTING_HEALTH
+} from '../services/duelService';
+import { sendHeartbeat, removeStalePlayersFromLobby } from '../services/lobbyService';
+
+/**
+ * Custom hook for managing a duel (1v1 multiplayer) game.
+ * Subscribes to the Firestore duel document and manages local guessing state.
+ *
+ * @param {string} lobbyDocId - The Firestore document ID of the lobby/duel
+ * @param {string} userUid - Current player's UID
+ * @param {string} userUsername - Current player's username
+ */
+export function useDuelGame(lobbyDocId, userUid, _userUsername) {
+  // --- Duel document state (from Firestore) ---
+  const [duelState, setDuelState] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // --- Local guessing state ---
+  const [localGuessLocation, setLocalGuessLocation] = useState(null);
+  const [localGuessFloor, setLocalGuessFloor] = useState(null);
+  const [localAvailableFloors, setLocalAvailableFloors] = useState(null);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [clickRejected, setClickRejected] = useState(false);
+
+  // --- Timer state ---
+  const [timeRemaining, setTimeRemaining] = useState(DUEL_ROUND_TIME_SECONDS);
+  const timedOutRef = useRef(false);
+  const roundKeyRef = useRef(0); // Track round changes to reset timer
+
+  // --- Map/region data ---
+  const [regions, setRegions] = useState([]);
+  const [playingArea, setPlayingArea] = useState(null);
+
+  // --- Refs for stable callbacks ---
+  const duelStateRef = useRef(duelState);
+  const hasSubmittedRef = useRef(hasSubmitted);
+  const hasLeft = useRef(false);
+  const processedRoundRef = useRef(0); // Track which round we already processed
+
+  // Keep refs in sync via useEffect (React lint requires this)
+  useEffect(() => {
+    duelStateRef.current = duelState;
+  }, [duelState]);
+
+  useEffect(() => {
+    hasSubmittedRef.current = hasSubmitted;
+  }, [hasSubmitted]);
+
+  // Load regions and playing area on mount
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [fetchedRegions, fetchedPlayingArea] = await Promise.all([
+          getRegions(),
+          getPlayingArea()
+        ]);
+        setRegions(fetchedRegions);
+        setPlayingArea(fetchedPlayingArea);
+      } catch (err) {
+        console.error('Failed to load regions/playing area:', err);
+        setRegions([]);
+        setPlayingArea(null);
+      }
+    }
+    loadData();
+  }, []);
+
+  // Subscribe to duel document
+  useEffect(() => {
+    if (!lobbyDocId) return;
+
+    const unsubscribe = subscribeDuel(lobbyDocId, (data) => {
+      setDuelState(data);
+      setIsLoading(false);
+
+      if (!data) {
+        setError('Game no longer exists.');
+      } else {
+        setError(null);
+      }
+    });
+
+    return () => unsubscribe();
+  }, [lobbyDocId]);
+
+  // Heartbeat for duel (keep presence alive)
+  useEffect(() => {
+    if (!lobbyDocId || !userUid) return;
+
+    sendHeartbeat(lobbyDocId, userUid).catch(() => {});
+
+    const heartbeatInterval = setInterval(() => {
+      if (!hasLeft.current) {
+        sendHeartbeat(lobbyDocId, userUid).catch(() => {});
+      }
+    }, 10_000);
+
+    return () => clearInterval(heartbeatInterval);
+  }, [lobbyDocId, userUid]);
+
+  // Stale player detection
+  useEffect(() => {
+    if (!lobbyDocId || !userUid) return;
+
+    const staleCheckInterval = setInterval(() => {
+      if (!hasLeft.current) {
+        removeStalePlayersFromLobby(lobbyDocId, userUid).catch(() => {});
+      }
+    }, 15_000);
+
+    return () => clearInterval(staleCheckInterval);
+  }, [lobbyDocId, userUid]);
+
+  // --- Derived state ---
+  const phase = duelState?.phase || null;
+  const currentRound = duelState?.currentRound || 0;
+  const currentImage = duelState?.currentImage || null;
+  const guesses = duelState?.guesses || {};
+  const health = duelState?.health || {};
+  const roundHistory = duelState?.roundHistory || [];
+  const players = useMemo(() => duelState?.players || [], [duelState?.players]);
+  const hostUid = duelState?.hostUid;
+  const isHost = hostUid === userUid;
+  const winner = duelState?.winner || null;
+  const loser = duelState?.loser || null;
+  const difficulty = duelState?.difficulty || 'all';
+
+  // Find opponent
+  const opponent = players.find(p => p.uid !== userUid);
+  const opponentUid = opponent?.uid || null;
+  const opponentUsername = opponent?.username || 'Opponent';
+
+  // Health values
+  const myHealth = health[userUid] ?? STARTING_HEALTH;
+  const opponentHealth = health[opponentUid] ?? STARTING_HEALTH;
+
+  // Guess states
+  const myGuess = guesses[userUid] || null;
+  const opponentGuess = guesses[opponentUid] || null;
+  const opponentHasSubmitted = !!opponentGuess;
+  const bothGuessed = !!myGuess && !!opponentGuess;
+
+  // Current round scores (from guesses)
+  const myScore = myGuess?.score ?? null;
+  const opponentScore = opponentGuess?.score ?? null;
+
+  // Reset local state when round changes (new round starts)
+  useEffect(() => {
+    if (phase === 'guessing' && currentRound > 0) {
+      const roundKey = currentRound;
+      if (roundKeyRef.current !== roundKey) {
+        roundKeyRef.current = roundKey;
+        setLocalGuessLocation(null); // eslint-disable-line react-hooks/set-state-in-effect -- Intentional: syncing local state from Firestore round changes
+        setLocalGuessFloor(null);
+        setLocalAvailableFloors(null);
+        setHasSubmitted(false);
+        timedOutRef.current = false;
+        setTimeRemaining(DUEL_ROUND_TIME_SECONDS);
+        processedRoundRef.current = 0;
+      }
+    }
+  }, [phase, currentRound]);
+
+  // --- Timer effect ---
+  useEffect(() => {
+    if (phase !== 'guessing' || !duelState?.roundStartedAt) {
+      return;
+    }
+
+    // Compute start time from Firestore timestamp
+    const roundStartMs = duelState.roundStartedAt.toMillis
+      ? duelState.roundStartedAt.toMillis()
+      : duelState.roundStartedAt;
+
+    const interval = setInterval(() => {
+      const elapsedSeconds = (Date.now() - roundStartMs) / 1000;
+      const remaining = Math.max(0, DUEL_ROUND_TIME_SECONDS - elapsedSeconds);
+      setTimeRemaining(remaining);
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+      }
+    }, 50);
+
+    return () => clearInterval(interval);
+  }, [phase, duelState?.roundStartedAt]);
+
+  // --- Auto-submit / timeout handling ---
+  useEffect(() => {
+    if (phase !== 'guessing') return;
+    if (timeRemaining > 0) return;
+    if (hasSubmittedRef.current) return;
+    if (!currentImage) return;
+    if (!lobbyDocId || !userUid) return;
+
+    // Timer expired and we haven't submitted yet
+    const isInRegion = localAvailableFloors !== null && localAvailableFloors.length > 0;
+    const hasValidGuess = localGuessLocation && (!isInRegion || localGuessFloor);
+
+    if (hasValidGuess) {
+      // Auto-submit the current guess
+      timedOutRef.current = true;
+      submitDuelGuess(lobbyDocId, userUid, {
+        location: localGuessLocation,
+        floor: localGuessFloor,
+        timedOut: true,
+        noGuess: false
+      }, currentImage).catch(err => console.error('Auto-submit failed:', err));
+      setHasSubmitted(true); // eslint-disable-line react-hooks/set-state-in-effect -- Intentional: timer expiry auto-submit
+    } else {
+      // No guess — submit empty
+      submitDuelGuess(lobbyDocId, userUid, {
+        location: null,
+        floor: null,
+        timedOut: true,
+        noGuess: true
+      }, currentImage).catch(err => console.error('No-guess submit failed:', err));
+      setHasSubmitted(true);
+    }
+  }, [phase, timeRemaining, localGuessLocation, localGuessFloor, localAvailableFloors, currentImage, lobbyDocId, userUid]);
+
+  // --- Host processes round when both have guessed ---
+  useEffect(() => {
+    if (!isHost) return;
+    if (phase !== 'guessing') return;
+    if (!bothGuessed) return;
+    if (processedRoundRef.current === currentRound) return;
+
+    processedRoundRef.current = currentRound;
+    processRound(lobbyDocId).catch(err => console.error('Process round failed:', err));
+  }, [isHost, phase, bothGuessed, currentRound, lobbyDocId]);
+
+  // --- Actions ---
+
+  /**
+   * Place a guess marker on the map
+   */
+  const placeMarker = useCallback((coords) => {
+    if (hasSubmitted) return false;
+
+    if (!isPointInPlayingArea(coords, playingArea)) {
+      setClickRejected(true);
+      setTimeout(() => setClickRejected(false), 500);
+      return false;
+    }
+
+    setLocalGuessLocation(coords);
+    setClickRejected(false);
+
+    const floors = getFloorsForPoint(coords, regions);
+    setLocalAvailableFloors(floors);
+
+    if (floors === null || (localGuessFloor && !floors.includes(localGuessFloor))) {
+      setLocalGuessFloor(null);
+    }
+
+    return true;
+  }, [hasSubmitted, playingArea, regions, localGuessFloor]);
+
+  /**
+   * Select a floor
+   */
+  const selectFloor = useCallback((floor) => {
+    if (hasSubmitted) return;
+    setLocalGuessFloor(floor);
+  }, [hasSubmitted]);
+
+  /**
+   * Submit the player's guess
+   */
+  const submitGuess = useCallback(async () => {
+    if (hasSubmitted) return;
+    if (!localGuessLocation || !currentImage) return;
+
+    const isInRegion = localAvailableFloors !== null && localAvailableFloors.length > 0;
+    if (isInRegion && !localGuessFloor) return;
+
+    setHasSubmitted(true);
+
+    try {
+      await submitDuelGuess(lobbyDocId, userUid, {
+        location: localGuessLocation,
+        floor: localGuessFloor,
+        timedOut: false,
+        noGuess: false
+      }, currentImage);
+    } catch (err) {
+      console.error('Submit guess failed:', err);
+      setHasSubmitted(false); // Allow retry
+    }
+  }, [hasSubmitted, localGuessLocation, localGuessFloor, localAvailableFloors, currentImage, lobbyDocId, userUid]);
+
+  /**
+   * Advance to next round (host only, after viewing results)
+   */
+  const nextRound = useCallback(async () => {
+    if (!isHost) return;
+    try {
+      await advanceToNextRound(lobbyDocId, difficulty);
+    } catch (err) {
+      console.error('Advance round failed:', err);
+    }
+  }, [isHost, lobbyDocId, difficulty]);
+
+  /**
+   * Get the username for a UID
+   */
+  const getUsernameForUid = useCallback((uid) => {
+    const player = players.find(p => p.uid === uid);
+    return player?.username || 'Unknown';
+  }, [players]);
+
+  return {
+    // State
+    duelState,
+    phase,
+    currentRound,
+    currentImage,
+    isLoading,
+    error,
+
+    // Local guess
+    localGuessLocation,
+    localGuessFloor,
+    localAvailableFloors,
+    hasSubmitted,
+    clickRejected,
+
+    // Opponent
+    opponentUid,
+    opponentUsername,
+    opponentHasSubmitted,
+
+    // Timer
+    timeRemaining,
+    roundTimeSeconds: DUEL_ROUND_TIME_SECONDS,
+
+    // Health
+    myHealth,
+    opponentHealth,
+
+    // Scores
+    myScore,
+    opponentScore,
+    myGuess,
+    opponentGuess,
+
+    // Game info
+    roundHistory,
+    winner,
+    loser,
+    isHost,
+    hostUid,
+    players,
+    difficulty,
+
+    // Map
+    playingArea,
+    regions,
+
+    // Actions
+    placeMarker,
+    selectFloor,
+    submitGuess,
+    nextRound,
+    getUsernameForUid
+  };
+}

--- a/react-vite-app/src/hooks/useGameState.js
+++ b/react-vite-app/src/hooks/useGameState.js
@@ -4,12 +4,12 @@ import { getRegions, getFloorsForPoint, getPlayingArea, isPointInPlayingArea } f
 
 const TOTAL_ROUNDS = 5;
 const MAX_SCORE_PER_ROUND = 5500; // 5000 for location + 500 floor bonus
-const ROUND_TIME_SECONDS = 20;
+export const ROUND_TIME_SECONDS = 20;
 
 /**
  * Calculate distance between two points (in percentage coordinates)
  */
-function calculateDistance(guess, actual) {
+export function calculateDistance(guess, actual) {
   const dx = guess.x - actual.x;
   const dy = guess.y - actual.y;
   return Math.sqrt(dx * dx + dy * dy);
@@ -21,7 +21,7 @@ function calculateDistance(guess, actual) {
  * At 10 ft (distance=5 in map coords) or closer, the player gets 5000.
  * Score drops very dramatically with distance, rewarding precise guesses.
  */
-function calculateLocationScore(distance) {
+export function calculateLocationScore(distance) {
   const maxScore = 5000;
   const perfectRadius = 5; // 10 ft = 5 percentage units (distance * 2 = feet)
   const maxDistance = Math.sqrt(100 * 100 + 100 * 100) - perfectRadius; // ~136.42

--- a/react-vite-app/src/services/duelService.js
+++ b/react-vite-app/src/services/duelService.js
@@ -1,0 +1,303 @@
+import {
+  doc,
+  getDoc,
+  updateDoc,
+  onSnapshot,
+  serverTimestamp,
+  Timestamp
+} from 'firebase/firestore';
+import { db } from '../firebase';
+import { getRandomImage } from './imageService';
+import { calculateDistance, calculateLocationScore } from '../hooks/useGameState';
+
+/** Starting health for each player */
+export const STARTING_HEALTH = 6000;
+
+/** Round time in seconds */
+export const DUEL_ROUND_TIME_SECONDS = 20;
+
+/**
+ * Get the damage multiplier for a given round number.
+ * Escalates as rounds progress (GeoGuessr Duels style).
+ *   Rounds 1-2: 1.0x
+ *   Rounds 3-4: 1.5x
+ *   Rounds 5+:  2.0x
+ */
+export function getDamageMultiplier(roundNumber) {
+  if (roundNumber <= 2) return 1.0;
+  if (roundNumber <= 4) return 1.5;
+  return 2.0;
+}
+
+/**
+ * Start a duel game from the lobby.
+ * Called by the host when both players are in the waiting room.
+ * Loads the first image, initialises health, and sets phase to 'guessing'.
+ *
+ * @param {string} docId - Firestore document ID of the lobby
+ * @param {Array} players - Array of { uid, username } from the lobby
+ * @param {string} difficulty - Difficulty filter for images
+ */
+export async function startDuel(docId, players, difficulty) {
+  const image = await getRandomImage(difficulty);
+
+  const health = {};
+  players.forEach(p => {
+    health[p.uid] = STARTING_HEALTH;
+  });
+
+  const lobbyRef = doc(db, 'lobbies', docId);
+  await updateDoc(lobbyRef, {
+    status: 'in_progress',
+    phase: 'guessing',
+    currentRound: 1,
+    currentImage: {
+      url: image.url,
+      correctLocation: image.correctLocation || { x: 50, y: 50 },
+      correctFloor: image.correctFloor ?? null,
+      difficulty: image.difficulty || difficulty
+    },
+    roundStartedAt: Timestamp.now(),
+    guesses: {},
+    health,
+    roundHistory: [],
+    winner: null,
+    loser: null,
+    finishedAt: null,
+    updatedAt: serverTimestamp()
+  });
+}
+
+/**
+ * Submit a player's guess for the current round.
+ * Calculates score client-side using the same formula as singleplayer.
+ *
+ * @param {string} docId - Lobby document ID
+ * @param {string} playerUid - Player's UID
+ * @param {object} guessData - { location: {x,y}|null, floor: number|null, timedOut: bool, noGuess: bool }
+ * @param {object} currentImage - The current image data with correctLocation/correctFloor
+ */
+export async function submitDuelGuess(docId, playerUid, guessData, currentImage) {
+  let score = 0;
+  let locationScore = 0;
+  let distance = null;
+  let floorCorrect = null;
+
+  if (guessData.location && !guessData.noGuess) {
+    const actualLocation = currentImage.correctLocation || { x: 50, y: 50 };
+    distance = calculateDistance(guessData.location, actualLocation);
+    locationScore = calculateLocationScore(distance);
+
+    const actualFloor = currentImage.correctFloor ?? null;
+
+    // Floor scoring logic (same as singleplayer)
+    if (guessData.floor !== null && actualFloor !== null) {
+      floorCorrect = guessData.floor === actualFloor;
+      score = floorCorrect ? locationScore : Math.round(locationScore * 0.8);
+    } else {
+      score = locationScore;
+    }
+  }
+
+  const lobbyRef = doc(db, 'lobbies', docId);
+  await updateDoc(lobbyRef, {
+    [`guesses.${playerUid}`]: {
+      location: guessData.location,
+      floor: guessData.floor ?? null,
+      score,
+      locationScore,
+      distance,
+      floorCorrect,
+      timedOut: guessData.timedOut || false,
+      noGuess: guessData.noGuess || false,
+      submittedAt: Timestamp.now()
+    },
+    updatedAt: serverTimestamp()
+  });
+}
+
+/**
+ * Process the round after both players have guessed.
+ * Calculates damage, updates health, pushes to roundHistory,
+ * and either starts the next round or ends the game.
+ *
+ * Only the host should call this to avoid race conditions.
+ *
+ * @param {string} docId - Lobby document ID
+ */
+export async function processRound(docId) {
+  const lobbyRef = doc(db, 'lobbies', docId);
+  const lobbySnap = await getDoc(lobbyRef);
+
+  if (!lobbySnap.exists()) return;
+
+  const lobby = lobbySnap.data();
+  const { players, guesses, health, currentRound, currentImage, roundHistory = [] } = lobby;
+
+  const playerUids = players.map(p => p.uid);
+  if (playerUids.length !== 2) return;
+
+  const [uid1, uid2] = playerUids;
+  const guess1 = guesses[uid1];
+  const guess2 = guesses[uid2];
+
+  if (!guess1 || !guess2) return;
+
+  // Calculate damage
+  const score1 = guess1.score || 0;
+  const score2 = guess2.score || 0;
+  const scoreDiff = Math.abs(score1 - score2);
+  const multiplier = getDamageMultiplier(currentRound);
+  const rawDamage = Math.round(scoreDiff * multiplier);
+
+  // Determine who takes damage
+  let damagedPlayer = null;
+  const newHealth = { ...health };
+
+  if (score1 < score2) {
+    damagedPlayer = uid1;
+    newHealth[uid1] = Math.max(0, newHealth[uid1] - rawDamage);
+  } else if (score2 < score1) {
+    damagedPlayer = uid2;
+    newHealth[uid2] = Math.max(0, newHealth[uid2] - rawDamage);
+  }
+  // If tied, no damage dealt
+
+  // Build round history entry
+  const roundEntry = {
+    roundNumber: currentRound,
+    imageUrl: currentImage.url,
+    actualLocation: currentImage.correctLocation,
+    actualFloor: currentImage.correctFloor ?? null,
+    players: {
+      [uid1]: {
+        location: guess1.location,
+        floor: guess1.floor,
+        score: score1,
+        locationScore: guess1.locationScore || 0,
+        distance: guess1.distance,
+        floorCorrect: guess1.floorCorrect,
+        timedOut: guess1.timedOut || false,
+        noGuess: guess1.noGuess || false
+      },
+      [uid2]: {
+        location: guess2.location,
+        floor: guess2.floor,
+        score: score2,
+        locationScore: guess2.locationScore || 0,
+        distance: guess2.distance,
+        floorCorrect: guess2.floorCorrect,
+        timedOut: guess2.timedOut || false,
+        noGuess: guess2.noGuess || false
+      }
+    },
+    damage: rawDamage,
+    multiplier,
+    damagedPlayer,
+    healthAfter: { ...newHealth }
+  };
+
+  const updatedHistory = [...roundHistory, roundEntry];
+
+  // Check if someone died
+  const gameOver = newHealth[uid1] <= 0 || newHealth[uid2] <= 0;
+
+  if (gameOver) {
+    const winner = newHealth[uid1] <= 0 ? uid2 : uid1;
+    const loser = winner === uid1 ? uid2 : uid1;
+
+    await updateDoc(lobbyRef, {
+      health: newHealth,
+      roundHistory: updatedHistory,
+      phase: 'finished',
+      winner,
+      loser,
+      finishedAt: serverTimestamp(),
+      updatedAt: serverTimestamp()
+    });
+  } else {
+    // Set phase to results so both players see the round results
+    await updateDoc(lobbyRef, {
+      health: newHealth,
+      roundHistory: updatedHistory,
+      phase: 'results',
+      updatedAt: serverTimestamp()
+    });
+  }
+}
+
+/**
+ * Advance to the next round after viewing results.
+ * Loads a new image, resets guesses, increments round.
+ * Only the host should call this.
+ *
+ * @param {string} docId - Lobby document ID
+ * @param {string} difficulty - Difficulty for image selection
+ */
+export async function advanceToNextRound(docId, difficulty) {
+  const image = await getRandomImage(difficulty);
+
+  const lobbyRef = doc(db, 'lobbies', docId);
+  const lobbySnap = await getDoc(lobbyRef);
+  if (!lobbySnap.exists()) return;
+
+  const lobby = lobbySnap.data();
+
+  await updateDoc(lobbyRef, {
+    currentRound: (lobby.currentRound || 1) + 1,
+    currentImage: {
+      url: image.url,
+      correctLocation: image.correctLocation || { x: 50, y: 50 },
+      correctFloor: image.correctFloor ?? null,
+      difficulty: image.difficulty || difficulty
+    },
+    roundStartedAt: Timestamp.now(),
+    guesses: {},
+    phase: 'guessing',
+    updatedAt: serverTimestamp()
+  });
+}
+
+/**
+ * Subscribe to a duel/lobby document for real-time updates.
+ * @param {string} docId - Firestore document ID
+ * @param {function} callback - Called with duel data on each update
+ * @returns {function} Unsubscribe function
+ */
+export function subscribeDuel(docId, callback) {
+  const lobbyRef = doc(db, 'lobbies', docId);
+  return onSnapshot(lobbyRef, (snapshot) => {
+    if (snapshot.exists()) {
+      callback({ docId: snapshot.id, ...snapshot.data() });
+    } else {
+      callback(null);
+    }
+  });
+}
+
+/**
+ * Handle opponent disconnect — award win to remaining player.
+ * @param {string} docId - Lobby document ID
+ * @param {string} winnerUid - The remaining player's UID
+ * @param {string} loserUid - The disconnected player's UID
+ */
+export async function handleOpponentDisconnect(docId, winnerUid, loserUid) {
+  const lobbyRef = doc(db, 'lobbies', docId);
+  const lobbySnap = await getDoc(lobbyRef);
+  if (!lobbySnap.exists()) return;
+
+  const lobby = lobbySnap.data();
+  if (lobby.phase === 'finished') return; // Already finished
+
+  const health = lobby.health || {};
+  health[loserUid] = 0;
+
+  await updateDoc(lobbyRef, {
+    health,
+    phase: 'finished',
+    winner: winnerUid,
+    loser: loserUid,
+    finishedAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  });
+}

--- a/react-vite-app/src/services/lobbyService.js
+++ b/react-vite-app/src/services/lobbyService.js
@@ -61,7 +61,7 @@ export async function createLobby(hostUid, hostUsername, difficulty, visibility)
     heartbeats: {
       [hostUid]: Timestamp.now()
     },
-    maxPlayers: 8,
+    maxPlayers: 2,
     createdAt: now,
     updatedAt: now
   };


### PR DESCRIPTION
## Summary
- **Implements a complete 1v1 duel system** modeled after GeoGuessr Duels, where two players compete head-to-head in unlimited rounds until one player's health reaches zero
- **Sets max lobby players to 2** and adds 3 new screen components (DuelGameScreen, DuelResultScreen, DuelFinalScreen) plus supporting service and hook (duelService.js, useDuelGame.js)
- **Key mechanics**: 6000 starting health, damage = score difference × escalating multiplier (1.0x → 1.5x → 2.0x), real-time Firestore sync with host-authority round processing, timer auto-submit, animated health bars and result map with both players' guesses

## Test plan
- [ ] Create a multiplayer lobby and verify max players is 2
- [ ] Join with a second player and verify the "Start Duel ⚔️" button appears for the host
- [ ] Start a duel and verify both players see the game screen with health bars
- [ ] Submit a guess and verify "Waiting for opponent..." overlay appears
- [ ] Verify result screen shows both players' guesses on the map with labels, scores, damage, and health bars
- [ ] Let timer expire without guessing to verify auto-submit and no-guess penalty (0 points)
- [ ] Play multiple rounds and verify damage multiplier escalates (1.0x rounds 1-2, 1.5x rounds 3-4, 2.0x round 5+)
- [ ] Play until one player reaches 0 health and verify KO banner + final screen appears
- [ ] Verify final screen shows victory/defeat, round history, and play again/home buttons
- [ ] Run `npm run build` — builds successfully
- [ ] Run `npx vitest run` — all 750 tests pass
- [ ] Run `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)