### PR TITLE
Add leaderboard for levels

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -17,6 +17,7 @@ import WaitingRoom from './components/WaitingRoom/WaitingRoom';
 import DuelGameScreen from './components/DuelGameScreen/DuelGameScreen';
 import DuelResultScreen from './components/DuelResultScreen/DuelResultScreen';
 import DuelFinalScreen from './components/DuelFinalScreen/DuelFinalScreen';
+import LeaderboardScreen from './components/LeaderboardScreen/LeaderboardScreen';
 import SubmissionApp from './components/SubmissionApp/SubmissionApp';
 import MessageBanner from './components/MessageBanner/MessageBanner';
 import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';
@@ -26,6 +27,7 @@ function App() {
   const { user, userDoc, loading, needsUsername, isAdmin } = useAuth();
   const [showSubmissionApp, setShowSubmissionApp] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
+  const [showLeaderboard, setShowLeaderboard] = useState(false);
 
   // Track whether we're in a duel (multiplayer) game
   const [inDuel, setInDuel] = useState(false);
@@ -70,7 +72,7 @@ function App() {
   );
 
   // Track user's online presence and current activity
-  usePresence(user, inDuel ? `duel-${duel.phase}` : screen, showSubmissionApp, showProfile, isAdmin);
+  usePresence(user, inDuel ? `duel-${duel.phase}` : screen, showSubmissionApp, showProfile, isAdmin, showLeaderboard);
 
   // Listen for admin messages sent to this user
   const { messages, dismissMessage } = useAdminMessages(user?.uid);
@@ -132,6 +134,17 @@ function App() {
         {messageBanner}
         <EmailVerificationBanner />
         <ProfileScreen onBack={() => setShowProfile(false)} />
+      </>
+    );
+  }
+
+  // Show leaderboard screen
+  if (showLeaderboard) {
+    return (
+      <>
+        {messageBanner}
+        <EmailVerificationBanner />
+        <LeaderboardScreen onBack={() => setShowLeaderboard(false)} />
       </>
     );
   }
@@ -217,6 +230,7 @@ function App() {
           onPlay={handlePlay}
           onOpenSubmission={() => setShowSubmissionApp(true)}
           onOpenProfile={() => setShowProfile(true)}
+          onOpenLeaderboard={() => setShowLeaderboard(true)}
           isLoading={isLoading}
         />
       )}

--- a/react-vite-app/src/components/LeaderboardScreen/LeaderboardScreen.css
+++ b/react-vite-app/src/components/LeaderboardScreen/LeaderboardScreen.css
@@ -1,0 +1,357 @@
+.leaderboard-screen {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow: hidden;
+  padding: 2rem 0;
+}
+
+.leaderboard-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.leaderboard-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 20% 80%, rgba(108, 181, 45, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(108, 181, 45, 0.08) 0%, transparent 40%);
+}
+
+.leaderboard-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(0deg, rgba(12, 12, 15, 0.8) 0%, transparent 50%),
+    linear-gradient(180deg, rgba(12, 12, 15, 0.4) 0%, transparent 30%);
+}
+
+.leaderboard-card {
+  position: relative;
+  z-index: 1;
+  background: rgba(22, 33, 62, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 700px;
+  margin: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+/* ── Back Button ── */
+.leaderboard-back-button {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.leaderboard-back-button:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text-primary);
+}
+
+/* ── Header ── */
+.leaderboard-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.leaderboard-icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.leaderboard-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.leaderboard-my-rank {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.leaderboard-my-rank strong {
+  color: var(--accent-green-light);
+  font-weight: 700;
+}
+
+/* ── Loading ── */
+.leaderboard-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 0;
+  color: var(--text-secondary);
+}
+
+/* ── Error ── */
+.leaderboard-error {
+  background: rgba(231, 76, 60, 0.15);
+  border: 1px solid rgba(231, 76, 60, 0.3);
+  border-radius: 8px;
+  color: #e74c3c;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+/* ── Empty State ── */
+.leaderboard-empty {
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+/* ── List ── */
+.leaderboard-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.leaderboard-list-header {
+  display: grid;
+  grid-template-columns: 60px 1fr 70px 90px 60px;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* ── Row ── */
+.leaderboard-row {
+  display: grid;
+  grid-template-columns: 60px 1fr 70px 90px 60px;
+  align-items: center;
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(42, 42, 74, 0.3);
+  transition: background 0.2s ease;
+}
+
+.leaderboard-row:last-child {
+  border-bottom: none;
+}
+
+.leaderboard-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* ── Current User Highlight ── */
+.leaderboard-row-me {
+  background: rgba(108, 181, 45, 0.08);
+  border: 1px solid rgba(108, 181, 45, 0.25);
+  border-radius: 8px;
+  margin: 2px 0;
+}
+
+.leaderboard-row-me:hover {
+  background: rgba(108, 181, 45, 0.12);
+}
+
+/* ── Top 3 Styling ── */
+.leaderboard-row-top1 {
+  background: rgba(255, 215, 0, 0.06);
+}
+
+.leaderboard-row-top1:hover {
+  background: rgba(255, 215, 0, 0.1);
+}
+
+.leaderboard-row-top2 {
+  background: rgba(192, 192, 192, 0.04);
+}
+
+.leaderboard-row-top2:hover {
+  background: rgba(192, 192, 192, 0.08);
+}
+
+.leaderboard-row-top3 {
+  background: rgba(205, 127, 50, 0.04);
+}
+
+.leaderboard-row-top3:hover {
+  background: rgba(205, 127, 50, 0.08);
+}
+
+/* ── Columns ── */
+.leaderboard-col-rank {
+  text-align: center;
+}
+
+.leaderboard-medal {
+  font-size: 1.3rem;
+}
+
+.leaderboard-rank-num {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.leaderboard-col-player {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.leaderboard-username {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.leaderboard-level-title {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.leaderboard-col-level {
+  text-align: center;
+}
+
+.leaderboard-level-badge {
+  background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  letter-spacing: 0.3px;
+  display: inline-block;
+}
+
+.leaderboard-col-xp {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-align: right;
+}
+
+.leaderboard-col-games {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+/* ── Separator ── */
+.leaderboard-separator {
+  text-align: center;
+  padding: 0.5rem 0;
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  letter-spacing: 4px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .leaderboard-card {
+    padding: 2rem 1.25rem;
+    margin: 0.5rem;
+  }
+
+  .leaderboard-list-header,
+  .leaderboard-row {
+    grid-template-columns: 45px 1fr 60px 75px 50px;
+    padding: 0.6rem 0.5rem;
+  }
+
+  .leaderboard-title {
+    font-size: 1.5rem;
+  }
+
+  .leaderboard-icon {
+    font-size: 2.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .leaderboard-screen {
+    padding: 1rem 0;
+  }
+
+  .leaderboard-card {
+    padding: 1.5rem 1rem;
+    margin: 0.25rem;
+    border-radius: 12px;
+  }
+
+  .leaderboard-list-header,
+  .leaderboard-row {
+    grid-template-columns: 40px 1fr 55px 65px;
+    font-size: 0.85rem;
+  }
+
+  /* Hide games column on small screens */
+  .leaderboard-col-games {
+    display: none;
+  }
+
+  .leaderboard-username {
+    font-size: 0.85rem;
+  }
+
+  .leaderboard-col-xp {
+    font-size: 0.78rem;
+  }
+
+  .leaderboard-level-badge {
+    font-size: 0.65rem;
+    padding: 0.15rem 0.4rem;
+  }
+
+  .leaderboard-medal {
+    font-size: 1.1rem;
+  }
+
+  .leaderboard-rank-num {
+    font-size: 0.8rem;
+  }
+
+  .leaderboard-back-button {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.75rem;
+  }
+}

--- a/react-vite-app/src/components/LeaderboardScreen/LeaderboardScreen.jsx
+++ b/react-vite-app/src/components/LeaderboardScreen/LeaderboardScreen.jsx
@@ -1,0 +1,171 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { getLeaderboard, getUserRank } from '../../services/leaderboardService';
+import './LeaderboardScreen.css';
+
+function LeaderboardScreen({ onBack }) {
+  const { user, userDoc, totalXp, levelInfo, levelTitle } = useAuth();
+
+  const [entries, setEntries] = useState([]);
+  const [myRank, setMyRank] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchLeaderboard() {
+      try {
+        const [leaderboard, rank] = await Promise.all([
+          getLeaderboard(50),
+          user ? getUserRank(user.uid, totalXp) : Promise.resolve(null)
+        ]);
+
+        if (!cancelled) {
+          setEntries(leaderboard);
+          setMyRank(rank);
+          setLoading(false);
+        }
+      } catch (err) {
+        console.error('Failed to load leaderboard:', err);
+        if (!cancelled) {
+          setError('Failed to load leaderboard. Please try again.');
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchLeaderboard();
+    return () => { cancelled = true; };
+  }, [user, totalXp]);
+
+  const isCurrentUser = (uid) => user?.uid === uid;
+  const userInTop = entries.some((e) => isCurrentUser(e.uid));
+
+  const getMedalEmoji = (rank) => {
+    if (rank === 1) return '🥇';
+    if (rank === 2) return '🥈';
+    if (rank === 3) return '🥉';
+    return null;
+  };
+
+  return (
+    <div className="leaderboard-screen">
+      <div className="leaderboard-background">
+        <div className="leaderboard-overlay"></div>
+      </div>
+
+      <div className="leaderboard-card">
+        <button className="leaderboard-back-button" onClick={onBack}>
+          ← Back
+        </button>
+
+        <div className="leaderboard-header">
+          <span className="leaderboard-icon">🏆</span>
+          <h1 className="leaderboard-title">Leaderboard</h1>
+          {myRank && (
+            <p className="leaderboard-my-rank">
+              Your Rank: <strong>#{myRank}</strong>
+            </p>
+          )}
+        </div>
+
+        {loading && (
+          <div className="leaderboard-loading">
+            <div className="loading-spinner"></div>
+            <p>Loading leaderboard...</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="leaderboard-error">{error}</div>
+        )}
+
+        {!loading && !error && entries.length === 0 && (
+          <div className="leaderboard-empty">
+            <p>No players found yet. Be the first to play!</p>
+          </div>
+        )}
+
+        {!loading && !error && entries.length > 0 && (
+          <div className="leaderboard-list">
+            <div className="leaderboard-list-header">
+              <span className="leaderboard-col-rank">Rank</span>
+              <span className="leaderboard-col-player">Player</span>
+              <span className="leaderboard-col-level">Level</span>
+              <span className="leaderboard-col-xp">XP</span>
+              <span className="leaderboard-col-games">Games</span>
+            </div>
+
+            {entries.map((entry) => {
+              const medal = getMedalEmoji(entry.rank);
+              const isMeClass = isCurrentUser(entry.uid) ? ' leaderboard-row-me' : '';
+              const topClass = entry.rank <= 3 ? ` leaderboard-row-top${entry.rank}` : '';
+
+              return (
+                <div
+                  key={entry.uid}
+                  className={`leaderboard-row${isMeClass}${topClass}`}
+                >
+                  <span className="leaderboard-col-rank">
+                    {medal ? (
+                      <span className="leaderboard-medal">{medal}</span>
+                    ) : (
+                      <span className="leaderboard-rank-num">#{entry.rank}</span>
+                    )}
+                  </span>
+
+                  <span className="leaderboard-col-player">
+                    <span className="leaderboard-username">{entry.username}</span>
+                    <span className="leaderboard-level-title">{entry.levelTitle}</span>
+                  </span>
+
+                  <span className="leaderboard-col-level">
+                    <span className="leaderboard-level-badge">Lvl {entry.level}</span>
+                  </span>
+
+                  <span className="leaderboard-col-xp">
+                    {entry.totalXp.toLocaleString()}
+                  </span>
+
+                  <span className="leaderboard-col-games">
+                    {entry.gamesPlayed}
+                  </span>
+                </div>
+              );
+            })}
+
+            {/* Show current user's position if they're not in the top list */}
+            {!userInTop && myRank && (
+              <>
+                <div className="leaderboard-separator">
+                  <span>...</span>
+                </div>
+                <div className="leaderboard-row leaderboard-row-me">
+                  <span className="leaderboard-col-rank">
+                    <span className="leaderboard-rank-num">#{myRank}</span>
+                  </span>
+                  <span className="leaderboard-col-player">
+                    <span className="leaderboard-username">{userDoc?.username ?? 'You'}</span>
+                    <span className="leaderboard-level-title">{levelTitle}</span>
+                  </span>
+                  <span className="leaderboard-col-level">
+                    <span className="leaderboard-level-badge">Lvl {levelInfo.level}</span>
+                  </span>
+                  <span className="leaderboard-col-xp">
+                    {totalXp.toLocaleString()}
+                  </span>
+                  <span className="leaderboard-col-games">
+                    {userDoc?.gamesPlayed ?? 0}
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default LeaderboardScreen;

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.css
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.css
@@ -43,6 +43,23 @@
   gap: 10px;
 }
 
+.title-leaderboard-button {
+  padding: 8px 16px;
+  background: rgba(255, 215, 0, 0.1);
+  border: 1px solid rgba(255, 215, 0, 0.25);
+  color: #ffd700;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.title-leaderboard-button:hover {
+  background: rgba(255, 215, 0, 0.2);
+  color: #ffe44d;
+}
+
 .title-profile-button {
   padding: 8px 16px;
   background: rgba(255, 255, 255, 0.08);
@@ -312,6 +329,7 @@
     gap: 6px;
   }
 
+  .title-leaderboard-button,
   .title-profile-button,
   .submit-photo-button,
   .title-logout-button {

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../../contexts/AuthContext';
 import './TitleScreen.css';
 
-function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, isLoading }) {
+function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenLeaderboard, isLoading }) {
   const { userDoc, logout, levelInfo, levelTitle } = useAuth();
 
   const handleLogout = async () => {
@@ -21,6 +21,9 @@ function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, isLoading }) {
           <span className="title-level-badge">Lvl {levelInfo.level}</span>
         </div>
         <div className="title-top-actions">
+          <button className="title-leaderboard-button" onClick={onOpenLeaderboard}>
+            Leaderboard
+          </button>
           <button className="title-profile-button" onClick={onOpenProfile}>
             Profile
           </button>

--- a/react-vite-app/src/hooks/usePresence.js
+++ b/react-vite-app/src/hooks/usePresence.js
@@ -11,7 +11,8 @@ const HEARTBEAT_INTERVAL_MS = 60 * 1000; // 60 seconds
 /**
  * Derive a friendly activity string from the app's current screen state.
  */
-function getActivityString(screen, showSubmissionApp, showProfile, isAdmin) {
+function getActivityString(screen, showSubmissionApp, showProfile, isAdmin, showLeaderboard) {
+  if (showLeaderboard) return 'Viewing Leaderboard';
   if (showProfile) return 'Viewing Profile';
   if (showSubmissionApp && isAdmin) return 'In Admin Panel';
   if (showSubmissionApp) return 'Submitting Photos';
@@ -41,12 +42,13 @@ function getActivityString(screen, showSubmissionApp, showProfile, isAdmin) {
  * @param {boolean} showSubmissionApp - Whether the submission/admin app is shown
  * @param {boolean} showProfile - Whether the profile screen is shown
  * @param {boolean} isAdmin - Whether the current user is an admin
+ * @param {boolean} showLeaderboard - Whether the leaderboard screen is shown
  */
-export function usePresence(user, screen, showSubmissionApp, showProfile, isAdmin) {
+export function usePresence(user, screen, showSubmissionApp, showProfile, isAdmin, showLeaderboard) {
   const prevUidRef = useRef(null);
   const activityRef = useRef('');
 
-  const currentActivity = getActivityString(screen, showSubmissionApp, showProfile, isAdmin);
+  const currentActivity = getActivityString(screen, showSubmissionApp, showProfile, isAdmin, showLeaderboard);
 
   // Set presence online when user logs in, offline when they log out
   useEffect(() => {

--- a/react-vite-app/src/services/leaderboardService.js
+++ b/react-vite-app/src/services/leaderboardService.js
@@ -1,0 +1,54 @@
+import { collection, query, orderBy, limit, getDocs, where, getCountFromServer } from 'firebase/firestore';
+import { db } from '../firebase';
+import { getLevelInfo, getLevelTitle } from '../utils/xpLevelling';
+
+/**
+ * Fetch the top players ordered by totalXp descending.
+ * Each entry includes computed level info.
+ * @param {number} limitCount - max number of players to return (default 50)
+ * @returns {Promise<Array<{ uid: string, username: string, totalXp: number, gamesPlayed: number, level: number, levelTitle: string, levelInfo: object }>>}
+ */
+export async function getLeaderboard(limitCount = 50) {
+  const usersRef = collection(db, 'users');
+  const q = query(usersRef, orderBy('totalXp', 'desc'), limit(limitCount));
+  const snapshot = await getDocs(q);
+
+  return snapshot.docs.map((docSnap, index) => {
+    const data = docSnap.data();
+    const totalXp = data.totalXp ?? 0;
+    const levelInfo = getLevelInfo(totalXp);
+    const levelTitle = getLevelTitle(levelInfo.level);
+
+    return {
+      uid: docSnap.id,
+      username: data.username ?? 'Unknown',
+      totalXp,
+      gamesPlayed: data.gamesPlayed ?? 0,
+      level: levelInfo.level,
+      levelTitle,
+      levelInfo,
+      rank: index + 1
+    };
+  });
+}
+
+/**
+ * Get the rank of a specific user (1-based).
+ * Counts how many users have more XP, then adds 1.
+ * @param {string} uid - the user's UID
+ * @param {number} userTotalXp - the user's total XP
+ * @returns {Promise<number>} rank (1 = highest)
+ */
+export async function getUserRank(uid, userTotalXp) {
+  const usersRef = collection(db, 'users');
+  const q = query(usersRef, where('totalXp', '>', userTotalXp));
+
+  try {
+    const countSnap = await getCountFromServer(q);
+    return countSnap.data().count + 1;
+  } catch {
+    // Fallback: if getCountFromServer isn't available, fetch docs
+    const snapshot = await getDocs(q);
+    return snapshot.size + 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new **Leaderboard** screen that ranks all players by total XP, displaying their level, level title, XP, and games played
- Top 3 players receive gold/silver/bronze medal styling; the current user's row is highlighted with a green accent
- If the current user isn't in the top 50, their position appears at the bottom with a separator showing their rank
- A gold-accented **Leaderboard** button is added to the title screen top bar
- User presence tracking updated to show "Viewing Leaderboard" activity

## Test plan
- [x] All 750 existing tests pass
- [x] Production build succeeds
- [ ] Verify the "Leaderboard" button appears on the title screen and has gold accent styling
- [ ] Click the button and verify the leaderboard loads with ranked player data
- [ ] Verify top 3 players show medal emojis (🥇🥈🥉) and tinted row backgrounds
- [ ] Verify the current user's row is highlighted with a green border
- [ ] Verify the back button returns to the title screen
- [ ] Test responsive layout on mobile (games column hides on small screens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)