### PR TITLE
Remove redundant level indicator from center of main menu

### DIFF
--- a/react-vite-app/src/components/TitleScreen/TitleScreen.css
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.css
@@ -205,7 +205,7 @@
 .tagline {
   font-size: 1.4rem;
   color: var(--text-secondary);
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
   font-weight: 400;
 }
 
@@ -220,29 +220,6 @@
   letter-spacing: 0.5px;
 }
 
-/* Level chip below tagline */
-.title-level-chip {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
-  padding: 0.4rem 1rem;
-  background: rgba(108, 181, 45, 0.1);
-  border: 1px solid rgba(108, 181, 45, 0.25);
-  border-radius: 20px;
-}
-
-.title-level-chip-level {
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--accent-green);
-}
-
-.title-level-chip-title {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
 
 .start-button {
   background: linear-gradient(135deg, var(--accent-green) 0%, var(--accent-green-hover) 100%);

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -2,7 +2,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import './TitleScreen.css';
 
 function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, onOpenLeaderboard, isLoading }) {
-  const { userDoc, logout, levelInfo, levelTitle } = useAuth();
+  const { userDoc, logout, levelInfo } = useAuth();
 
   const handleLogout = async () => {
     try {
@@ -47,12 +47,6 @@ function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, o
         </div>
         <h1 className="game-title">HW Geoguessr</h1>
         <p className="tagline">Can you guess the location on campus?</p>
-
-        {/* Level chip under tagline */}
-        <div className="title-level-chip">
-          <span className="title-level-chip-level">Lvl {levelInfo.level}</span>
-          <span className="title-level-chip-title">{levelTitle}</span>
-        </div>
 
         <button
           className="start-button"


### PR DESCRIPTION
## Summary
- Removed the level chip (`title-level-chip`) from the center of the title screen, which duplicated the level info already displayed in the top bar's level badge
- Cleaned up the associated CSS classes (`title-level-chip`, `title-level-chip-level`, `title-level-chip-title`) and the unused `levelTitle` import
- Adjusted `.tagline` margin to maintain proper spacing between the tagline and the Play button

## Test plan
- [ ] Verify the main menu no longer shows a level chip below the tagline
- [ ] Verify the top bar still shows the level badge next to the username
- [ ] Verify spacing between the tagline and Play button looks correct
- [ ] Check responsive layouts (mobile/tablet) still look good

🤖 Generated with [Claude Code](https://claude.com/claude-code)