### PR TITLE
Add pan support to ResultScreen and DuelResultScreen maps

### DIFF
--- a/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.css
+++ b/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.css
@@ -76,6 +76,16 @@
   transform-origin: 0 0;
 }
 
+/* Cursor changes when duel result map is zoomed */
+.duel-result-map.zoomed {
+  cursor: grab;
+  touch-action: none;
+}
+
+.duel-result-map.zoomed:active {
+  cursor: grabbing;
+}
+
 /* ── Markers ── */
 .duel-pin-red {
   background: linear-gradient(135deg, #ff4757 0%, #ff6b81 100%);

--- a/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.jsx
+++ b/react-vite-app/src/components/DuelResultScreen/DuelResultScreen.jsx
@@ -71,7 +71,7 @@ function DuelResultScreen({
     return () => observer.disconnect();
   }, []);
 
-  const { scale, transformStyle, zoomIn, zoomOut, resetZoom } = useMapZoom(mapContainerRef);
+  const { scale, transformStyle, handlers, zoomIn, zoomOut, resetZoom, isPanning } = useMapZoom(mapContainerRef);
   const isZoomed = scale > 1;
 
   // Animation sequence
@@ -150,9 +150,13 @@ function DuelResultScreen({
       <div className="duel-result-content">
         {/* Map */}
         <div className="duel-result-map-container" ref={mapOuterRef}>
-          <div className="duel-result-map" ref={mapContainerRef}>
+          <div
+            className={`duel-result-map ${isZoomed ? 'zoomed' : ''} ${isPanning ? 'is-panning' : ''}`}
+            ref={mapContainerRef}
+            {...handlers}
+          >
             <div className="duel-result-zoom-content" style={{ transform: transformStyle }}>
-              <img className="map-image" src="/FINAL_MAP.png" alt="Campus Map" />
+              <img className="map-image" src="/FINAL_MAP.png" alt="Campus Map" draggable="false" onDragStart={(e) => e.preventDefault()} />
 
               {/* Lines from guesses to actual */}
               {animationPhase >= 2 && (

--- a/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
+++ b/react-vite-app/src/components/ResultScreen/ResultScreen.jsx
@@ -72,9 +72,11 @@ function ResultScreen({
   const {
     scale,
     transformStyle,
+    handlers,
     zoomIn,
     zoomOut,
-    resetZoom
+    resetZoom,
+    isPanning
   } = useMapZoom(mapContainerRef);
 
   const isZoomed = scale > 1;
@@ -167,7 +169,11 @@ function ResultScreen({
       {/* Main content - Map with results */}
       <div className="result-content">
         <div className="result-map-container" ref={mapOuterRef}>
-          <div className="result-map" ref={mapContainerRef}>
+          <div
+            className={`result-map ${isZoomed ? 'zoomed' : ''} ${isPanning ? 'is-panning' : ''}`}
+            ref={mapContainerRef}
+            {...handlers}
+          >
             <div
               className="result-zoom-content"
               style={{ transform: transformStyle }}
@@ -177,6 +183,8 @@ function ResultScreen({
                 className="map-image"
                 src="/FINAL_MAP.png"
                 alt="Campus Map"
+                draggable="false"
+                onDragStart={(e) => e.preventDefault()}
               />
 
               {/* Line between guess and actual (Phase 2+) */}


### PR DESCRIPTION
## Summary
- Wired up existing `useMapZoom` panning handlers (`handlers`, `isPanning`) to the `ResultScreen` and `DuelResultScreen` map containers, enabling click-and-drag panning when zoomed in
- Added `draggable="false"` to map images in both screens to prevent browser image drag from interfering with panning
- Added `zoomed`/`is-panning` CSS classes and grab cursor styles to `DuelResultScreen` (already existed for `ResultScreen`)

## Test plan
- [ ] Open a solo game result screen, zoom in on the map, and verify you can click-and-drag to pan
- [ ] Verify the cursor changes to a grab hand when zoomed and grabbing when dragging
- [ ] Open a duel result screen, zoom in, and verify panning works identically
- [ ] Verify touch panning works on mobile (single-finger drag when zoomed)
- [ ] Verify that zoom controls (+, -, reset) still function correctly on both screens
- [ ] Confirm all 750 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)