### PR TITLE
Add ability to delete photos in admin review

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/AdminReview.css
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.css
@@ -924,6 +924,146 @@
   transform: translateY(0);
 }
 
+/* ===== Modal Header Actions ===== */
+.modal-header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* ===== Delete Photo Button ===== */
+.delete-photo-button {
+  padding: 8px 20px;
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.delete-photo-button:hover {
+  background: rgba(248, 113, 113, 0.25);
+  box-shadow: 0 4px 15px rgba(248, 113, 113, 0.2);
+  transform: translateY(-1px);
+}
+
+.card-actions .delete-photo-button {
+  flex: 1;
+  padding: 10px;
+  border-radius: 12px;
+}
+
+/* ===== Delete Confirmation Popup ===== */
+.delete-confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(10px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+  animation: modalOverlayIn 0.2s ease-out;
+}
+
+.delete-confirm-modal {
+  background: linear-gradient(145deg, #1e1e3a 0%, #161630 100%);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+  border-radius: 20px;
+  max-width: 420px;
+  width: 100%;
+  overflow: hidden;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.6), 0 0 40px rgba(248, 113, 113, 0.08);
+  animation: modalSlideIn 0.3s ease-out;
+}
+
+.delete-confirm-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  background: rgba(0, 0, 0, 0.3);
+  display: block;
+}
+
+.delete-confirm-body {
+  padding: 24px;
+}
+
+.delete-confirm-title {
+  margin: 0 0 10px 0;
+  color: #f87171;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.delete-confirm-message {
+  margin: 0 0 20px 0;
+  color: #b0b8cc;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.delete-confirm-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.delete-confirm-button {
+  flex: 1;
+  padding: 12px;
+  background: linear-gradient(135deg, #dc2626 0%, #ef4444 100%);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 700;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 15px rgba(239, 68, 68, 0.25);
+}
+
+.delete-confirm-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(239, 68, 68, 0.35);
+}
+
+.delete-confirm-button:disabled {
+  background: linear-gradient(135deg, #374151 0%, #4b5563 100%);
+  color: #6b7280;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.delete-cancel-button {
+  flex: 1;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #b0b8cc;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 700;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.delete-cancel-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.delete-cancel-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Responsive: stack info grid on small screens */
 @media (max-width: 600px) {
   .detail-info-grid {

--- a/react-vite-app/src/services/imageService.js
+++ b/react-vite-app/src/services/imageService.js
@@ -1,4 +1,4 @@
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { collection, getDocs, query, where, deleteDoc, doc } from 'firebase/firestore';
 import { db } from '../firebase';
 
 // Sample images for development/testing
@@ -142,4 +142,20 @@ export async function getAllImages() {
  */
 export function getAllSampleImages() {
   return [...SAMPLE_IMAGES];
+}
+
+/**
+ * Deletes a submission from the submissions collection
+ * @param {string} submissionId - The Firestore document ID of the submission
+ */
+export async function deleteSubmission(submissionId) {
+  await deleteDoc(doc(db, 'submissions', submissionId));
+}
+
+/**
+ * Deletes an image from the images collection
+ * @param {string} imageId - The Firestore document ID of the image
+ */
+export async function deleteImage(imageId) {
+  await deleteDoc(doc(db, 'images', imageId));
 }


### PR DESCRIPTION
## Summary
- Adds delete buttons on photo cards and in the detail modal for submissions and game images (testing data excluded)
- Implements a confirmation popup with photo thumbnail preview and warning message before permanent deletion
- Adds `deleteSubmission()` and `deleteImage()` service functions for Firestore document removal

## Test plan
- [x] All 767 existing + new tests pass (15 new delete tests added)
- [x] Build succeeds with no errors
- [x] ESLint passes clean
- [ ] Verify delete button appears on submission and game image cards but not on testing data
- [ ] Verify clicking Delete opens confirmation popup with photo preview
- [ ] Verify Cancel dismisses the popup without deleting
- [ ] Verify confirming delete removes the photo from Firestore and updates the UI
- [ ] Verify deleting from the detail modal closes both the modal and confirmation popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)