### PR TITLE
Add spacebar-to-place-marker and number-key floor selection shortcuts

### DIFF
--- a/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
+++ b/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import ImageViewer from '../ImageViewer/ImageViewer';
 import MapPicker from '../MapPicker/MapPicker';
 import FloorSelector from '../FloorSelector/FloorSelector';
@@ -27,15 +27,35 @@ function DuelGameScreen({
   opponentHealth,
   myUsername = 'You'
 }) {
+  const mapPickerRef = useRef(null);
+
   const isInRegion = availableFloors !== null && availableFloors.length > 0;
   const canSubmit = !hasSubmitted && guessLocation !== null && (!isInRegion || guessFloor !== null);
 
   const handleKeyDown = useCallback((e) => {
-    if (e.code === 'Space' && canSubmit) {
+    if (hasSubmitted) return;
+
+    // Spacebar: submit guess if ready, otherwise place marker at map center
+    if (e.code === 'Space') {
       e.preventDefault();
-      onSubmitGuess();
+      if (canSubmit) {
+        onSubmitGuess();
+      } else if (!guessLocation && mapPickerRef.current) {
+        const center = mapPickerRef.current.getViewportCenter();
+        onMapClick(center);
+      }
+      return;
     }
-  }, [canSubmit, onSubmitGuess]);
+
+    // Number keys (1-9): select floor when floor selector is visible
+    if (isInRegion && availableFloors) {
+      const digit = parseInt(e.key, 10);
+      if (!isNaN(digit) && digit >= 1 && availableFloors.includes(digit)) {
+        e.preventDefault();
+        onFloorSelect(digit);
+      }
+    }
+  }, [hasSubmitted, canSubmit, onSubmitGuess, guessLocation, onMapClick, isInRegion, availableFloors, onFloorSelect]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
@@ -160,6 +180,7 @@ function DuelGameScreen({
           {!hasSubmitted && (
             <div className="guess-controls">
               <MapPicker
+                ref={mapPickerRef}
                 markerPosition={guessLocation}
                 onMapClick={onMapClick}
                 clickRejected={clickRejected}

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import ImageViewer from '../ImageViewer/ImageViewer';
 import MapPicker from '../MapPicker/MapPicker';
 import FloorSelector from '../FloorSelector/FloorSelector';
@@ -21,6 +21,8 @@ function GameScreen({
   timeRemaining,
   timeLimitSeconds = 20
 }) {
+  const mapPickerRef = useRef(null);
+
   // Can submit if location is selected AND either:
   // - not in a region (availableFloors is null), OR
   // - in a region with floors and a floor is selected
@@ -28,11 +30,27 @@ function GameScreen({
   const canSubmit = guessLocation !== null && (!isInRegion || guessFloor !== null);
 
   const handleKeyDown = useCallback((e) => {
-    if (e.code === 'Space' && canSubmit) {
+    // Spacebar: submit guess if ready, otherwise place marker at map center
+    if (e.code === 'Space') {
       e.preventDefault();
-      onSubmitGuess();
+      if (canSubmit) {
+        onSubmitGuess();
+      } else if (!guessLocation && mapPickerRef.current) {
+        const center = mapPickerRef.current.getViewportCenter();
+        onMapClick(center);
+      }
+      return;
     }
-  }, [canSubmit, onSubmitGuess]);
+
+    // Number keys (1-9): select floor when floor selector is visible
+    if (isInRegion && availableFloors) {
+      const digit = parseInt(e.key, 10);
+      if (!isNaN(digit) && digit >= 1 && availableFloors.includes(digit)) {
+        e.preventDefault();
+        onFloorSelect(digit);
+      }
+    }
+  }, [canSubmit, onSubmitGuess, guessLocation, onMapClick, isInRegion, availableFloors, onFloorSelect]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
@@ -100,6 +118,7 @@ function GameScreen({
 
         <div className="guess-controls">
           <MapPicker
+            ref={mapPickerRef}
             markerPosition={guessLocation}
             onMapClick={onMapClick}
             clickRejected={clickRejected}


### PR DESCRIPTION
## Summary
- **Spacebar as map click**: When no guess has been placed yet, pressing spacebar now places a marker at the center of the current map viewport (accounting for zoom/pan), giving keyboard-only users a quick way to start guessing.
- **Number keys for floor selection**: When the floor selector is visible, pressing a number key (1–9) selects the corresponding floor if it's available.
- Both shortcuts are implemented in singleplayer (`GameScreen`) and duel (`DuelGameScreen`) modes.

## Test plan
- [ ] Start a singleplayer game, press spacebar before clicking the map — a marker should appear at the center of the viewport
- [ ] Zoom/pan the map, then press spacebar — the marker should appear at the center of the *visible* area
- [ ] After placing a marker in a region with floors, press a number key (e.g., `1`, `2`, `3`) to select that floor
- [ ] Pressing a number key for a floor not in the available list should do nothing
- [ ] Once a complete guess is ready (location + floor if needed), spacebar should still submit the guess
- [ ] Verify the same behavior in duel mode
- [ ] After submitting in duel mode, keyboard shortcuts should be disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)