### PR TITLE
Add daily goals feature with progress tracking and bonus XP

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -21,6 +21,7 @@ import LeaderboardScreen from './components/LeaderboardScreen/LeaderboardScreen'
 import SubmissionApp from './components/SubmissionApp/SubmissionApp';
 import FriendsPanel from './components/FriendsPanel/FriendsPanel';
 import ChatWindow from './components/ChatWindow/ChatWindow';
+import DailyGoalsPanel from './components/DailyGoalsPanel/DailyGoalsPanel';
 import MessageBanner from './components/MessageBanner/MessageBanner';
 import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';
 import './App.css';
@@ -33,6 +34,7 @@ function App() {
   const [showChat, setShowChat] = useState(false);
   const [chatFriend, setChatFriend] = useState(null); // { uid, username }
   const [showLeaderboard, setShowLeaderboard] = useState(false);
+  const [showDailyGoals, setShowDailyGoals] = useState(false);
 
   // Track whether we're in a duel (multiplayer) game
   const [inDuel, setInDuel] = useState(false);
@@ -207,6 +209,17 @@ function App() {
     );
   }
 
+  // Show daily goals panel
+  if (showDailyGoals) {
+    return (
+      <>
+        {messageBanner}
+        <EmailVerificationBanner />
+        <DailyGoalsPanel onBack={() => setShowDailyGoals(false)} />
+      </>
+    );
+  }
+
   // Show submission app
   if (showSubmissionApp) {
     return (
@@ -290,6 +303,7 @@ function App() {
           onOpenProfile={() => setShowProfile(true)}
           onOpenFriends={() => setShowFriends(true)}
           onOpenLeaderboard={() => setShowLeaderboard(true)}
+          onOpenDailyGoals={() => setShowDailyGoals(true)}
           isLoading={isLoading}
         />
       )}
@@ -372,6 +386,7 @@ function App() {
           rounds={roundResults}
           onPlayAgain={() => setScreen('difficultySelect')}
           onBackToTitle={resetGame}
+          difficulty={difficulty}
         />
       )}
 

--- a/react-vite-app/src/components/DailyGoalsPanel/DailyGoalsPanel.css
+++ b/react-vite-app/src/components/DailyGoalsPanel/DailyGoalsPanel.css
@@ -1,0 +1,295 @@
+/* ===== Daily Goals Panel ===== */
+.daily-goals-panel {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.daily-goals-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #0c0c0f 0%, #1a1a2e 50%, #16213e 100%);
+  z-index: 0;
+}
+
+.daily-goals-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image:
+    radial-gradient(circle at 25% 75%, rgba(255, 193, 7, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 75% 25%, rgba(108, 181, 45, 0.08) 0%, transparent 40%);
+}
+
+.daily-goals-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background:
+    linear-gradient(0deg, rgba(12, 12, 15, 0.8) 0%, transparent 50%),
+    linear-gradient(180deg, rgba(12, 12, 15, 0.4) 0%, transparent 30%);
+}
+
+.daily-goals-card {
+  position: relative;
+  z-index: 1;
+  background: rgba(22, 33, 62, 0.6);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 550px;
+  margin: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.daily-goals-card::-webkit-scrollbar {
+  width: 6px;
+}
+.daily-goals-card::-webkit-scrollbar-track {
+  background: transparent;
+}
+.daily-goals-card::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.daily-goals-back-button {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: #b0b8cc;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.daily-goals-back-button:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
+.daily-goals-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #e0e6f0;
+  text-align: center;
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.daily-goals-subtitle {
+  text-align: center;
+  color: #8892a8;
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ===== Progress Summary ===== */
+.daily-goals-progress-summary {
+  margin-bottom: 1.5rem;
+}
+
+.daily-goals-progress-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.daily-goals-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ffc107, #6cb52d);
+  border-radius: 4px;
+  transition: width 0.5s ease;
+}
+
+.daily-goals-progress-text {
+  display: block;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #8892a8;
+  font-weight: 600;
+}
+
+/* ===== Error & Loading ===== */
+.daily-goals-error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #f87171;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+  text-align: center;
+}
+
+.daily-goals-loading {
+  text-align: center;
+  color: #8892a8;
+  padding: 2rem;
+  font-size: 0.95rem;
+}
+
+/* ===== Goal List ===== */
+.daily-goals-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.daily-goal-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  transition: all 0.25s ease;
+}
+
+.daily-goal-item.completed {
+  border-color: rgba(108, 181, 45, 0.2);
+  background: rgba(108, 181, 45, 0.05);
+}
+
+.daily-goal-check {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.daily-goal-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.daily-goal-description {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e0e6f0;
+  margin-bottom: 8px;
+}
+
+.daily-goal-item.completed .daily-goal-description {
+  color: #6cb52d;
+}
+
+.daily-goal-progress-bar {
+  width: 100%;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.daily-goal-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ffc107, #ffca28);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+.daily-goal-item.completed .daily-goal-progress-fill {
+  background: linear-gradient(90deg, #6cb52d, #85d147);
+}
+
+.daily-goal-progress-text {
+  font-size: 0.78rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* ===== Bonus Section ===== */
+.daily-goals-bonus-section {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.daily-goals-claim-button {
+  display: inline-block;
+  padding: 14px 32px;
+  background: linear-gradient(135deg, #ffc107 0%, #ff9800 100%);
+  color: #1a1a2e;
+  border: none;
+  border-radius: 50px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 20px rgba(255, 193, 7, 0.4);
+}
+
+.daily-goals-claim-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 30px rgba(255, 193, 7, 0.5);
+}
+
+.daily-goals-claim-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.daily-goals-bonus-claimed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 24px;
+  background: rgba(108, 181, 45, 0.1);
+  border: 1px solid rgba(108, 181, 45, 0.25);
+  border-radius: 12px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #6cb52d;
+}
+
+.bonus-claimed-icon {
+  font-size: 1.3rem;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 480px) {
+  .daily-goals-card {
+    padding: 2rem 1.25rem;
+    margin: 0.5rem;
+  }
+
+  .daily-goals-title {
+    font-size: 1.5rem;
+  }
+
+  .daily-goal-item {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .daily-goal-description {
+    font-size: 0.9rem;
+  }
+}

--- a/react-vite-app/src/components/DailyGoalsPanel/DailyGoalsPanel.jsx
+++ b/react-vite-app/src/components/DailyGoalsPanel/DailyGoalsPanel.jsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useDailyGoals } from '../../hooks/useDailyGoals';
+import './DailyGoalsPanel.css';
+
+function DailyGoalsPanel({ onBack }) {
+  const { user, refreshUserDoc } = useAuth();
+  const {
+    goals,
+    allCompleted,
+    bonusXpAwarded,
+    bonusXpAmount,
+    loading,
+    error,
+    claimBonusXp
+  } = useDailyGoals(user?.uid);
+
+  const [claiming, setClaiming] = useState(false);
+  const [claimed, setClaimed] = useState(false);
+
+  const handleClaimBonus = async () => {
+    setClaiming(true);
+    try {
+      await claimBonusXp();
+      await refreshUserDoc();
+      setClaimed(true);
+    } catch (err) {
+      console.error('Claim failed:', err);
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  const completedCount = goals.filter(g => g.completed).length;
+
+  return (
+    <div className="daily-goals-panel">
+      <div className="daily-goals-background">
+        <div className="daily-goals-overlay"></div>
+      </div>
+      <div className="daily-goals-card">
+        <button className="daily-goals-back-button" onClick={onBack}>
+          &larr; Back
+        </button>
+
+        <h1 className="daily-goals-title">Daily Goals</h1>
+        <p className="daily-goals-subtitle">
+          Complete all goals to earn {bonusXpAmount.toLocaleString()} bonus XP!
+        </p>
+
+        {/* Progress summary */}
+        <div className="daily-goals-progress-summary">
+          <div className="daily-goals-progress-bar">
+            <div
+              className="daily-goals-progress-fill"
+              style={{ width: `${goals.length > 0 ? (completedCount / goals.length) * 100 : 0}%` }}
+            />
+          </div>
+          <span className="daily-goals-progress-text">
+            {completedCount} / {goals.length} completed
+          </span>
+        </div>
+
+        {error && <div className="daily-goals-error">{error}</div>}
+
+        {loading ? (
+          <div className="daily-goals-loading">Loading goals...</div>
+        ) : (
+          <div className="daily-goals-list">
+            {goals.map((goal) => (
+              <div
+                key={goal.id}
+                className={`daily-goal-item ${goal.completed ? 'completed' : ''}`}
+              >
+                <div className="daily-goal-check">
+                  {goal.completed ? '\u2705' : '\u2B1C'}
+                </div>
+                <div className="daily-goal-info">
+                  <span className="daily-goal-description">{goal.description}</span>
+                  <div className="daily-goal-progress-bar">
+                    <div
+                      className="daily-goal-progress-fill"
+                      style={{
+                        width: `${Math.min(100, (goal.current / goal.target) * 100)}%`
+                      }}
+                    />
+                  </div>
+                  <span className="daily-goal-progress-text">
+                    {goal.isThreshold
+                      ? `Best: ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}`
+                      : `${Math.min(goal.current, goal.target)} / ${goal.target}`}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Bonus section */}
+        {allCompleted && (
+          <div className="daily-goals-bonus-section">
+            {bonusXpAwarded || claimed ? (
+              <div className="daily-goals-bonus-claimed">
+                <span className="bonus-claimed-icon">{'\uD83C\uDF89'}</span>
+                <span>+{bonusXpAmount.toLocaleString()} XP Claimed!</span>
+              </div>
+            ) : (
+              <button
+                className="daily-goals-claim-button"
+                onClick={handleClaimBonus}
+                disabled={claiming}
+              >
+                {claiming ? 'Claiming...' : `Claim ${bonusXpAmount.toLocaleString()} Bonus XP`}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DailyGoalsPanel;

--- a/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.jsx
+++ b/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.jsx
@@ -1,5 +1,7 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { STARTING_HEALTH } from '../../services/duelService';
+import { useDailyGoals } from '../../hooks/useDailyGoals';
+import { GOAL_TYPES } from '../../utils/dailyGoalDefinitions';
 import './DuelFinalScreen.css';
 
 const CONFETTI_COLORS = ['#6cb52d', '#ffc107', '#ff4757', '#3498db', '#9b59b6', '#e74c3c'];
@@ -24,6 +26,8 @@ function DuelFinalScreen({
   onBackToTitle
 }) {
   const [animationComplete, setAnimationComplete] = useState(false);
+  const { recordProgress } = useDailyGoals(myUid);
+  const goalsRecorded = useRef(false);
 
   const confettiPieces = useMemo(() => generateConfettiData(40), []);
 
@@ -66,6 +70,23 @@ function DuelFinalScreen({
     const timer = setTimeout(() => setAnimationComplete(true), 1500);
     return () => clearTimeout(timer);
   }, []);
+
+  // Record daily goal progress for duel completion
+  useEffect(() => {
+    if (goalsRecorded.current || !myUid) return;
+    goalsRecorded.current = true;
+
+    // Goal: play a duel
+    recordProgress(GOAL_TYPES.PLAY_DUEL, 1);
+
+    // Goal: win a duel
+    if (winner === myUid) {
+      recordProgress(GOAL_TYPES.WIN_DUEL, 1);
+    }
+
+    // Goal: games played (duels count as games)
+    recordProgress(GOAL_TYPES.GAMES_PLAYED, 1);
+  }, [myUid, winner, recordProgress]);
 
   return (
     <div className="duel-final-screen">

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.css
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.css
@@ -43,6 +43,24 @@
   gap: 10px;
 }
 
+.title-daily-goals-button {
+  padding: 8px 16px;
+  background: rgba(255, 193, 7, 0.15);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+  color: #ffc107;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.title-daily-goals-button:hover {
+  background: rgba(255, 193, 7, 0.25);
+  color: #ffca28;
+  transform: translateY(-1px);
+}
+
 .title-leaderboard-button {
   padding: 8px 16px;
   background: rgba(255, 215, 0, 0.1);
@@ -347,6 +365,7 @@
     gap: 6px;
   }
 
+  .title-daily-goals-button,
   .title-leaderboard-button,
   .title-profile-button,
   .title-friends-button,

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../../contexts/AuthContext';
 import './TitleScreen.css';
 
-function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, onOpenLeaderboard, isLoading }) {
+function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, onOpenLeaderboard, onOpenDailyGoals, isLoading }) {
   const { userDoc, logout, levelInfo, levelTitle } = useAuth();
 
   const handleLogout = async () => {
@@ -21,6 +21,9 @@ function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, o
           <span className="title-level-badge">Lvl {levelInfo.level}</span>
         </div>
         <div className="title-top-actions">
+          <button className="title-daily-goals-button" onClick={onOpenDailyGoals}>
+            Daily Goals
+          </button>
           <button className="title-leaderboard-button" onClick={onOpenLeaderboard}>
             Leaderboard
           </button>

--- a/react-vite-app/src/hooks/useDailyGoals.js
+++ b/react-vite-app/src/hooks/useDailyGoals.js
@@ -1,0 +1,94 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import {
+  getOrCreateDailyGoals,
+  recordGoalProgress,
+  markBonusXpAwarded
+} from '../services/dailyGoalsService';
+import { awardXp } from '../services/xpService';
+import { GOAL_TYPES } from '../utils/dailyGoalDefinitions';
+
+/**
+ * Hook for managing daily goals state.
+ *
+ * @param {string|null} uid — Current user's UID (null when logged out)
+ * @returns {{ goals, allCompleted, bonusXpAwarded, bonusXpAmount, loading, error, refreshGoals, recordProgress, claimBonusXp, GOAL_TYPES }}
+ */
+export function useDailyGoals(uid) {
+  const [goalsData, setGoalsData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Fetch/create goals on mount and when uid changes
+  const refreshGoals = useCallback(async () => {
+    if (!uid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getOrCreateDailyGoals(uid);
+      setGoalsData(data);
+    } catch (err) {
+      console.error('Failed to load daily goals:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [uid]);
+
+  useEffect(() => {
+    refreshGoals();
+  }, [refreshGoals]);
+
+  /**
+   * Record progress toward a goal type.
+   * Called by integration points (FinalResultsScreen, DuelFinalScreen, etc.)
+   */
+  const recordProgress = useCallback(async (goalType, value = 1, params = {}) => {
+    if (!uid) return;
+    try {
+      const result = await recordGoalProgress(uid, goalType, value, params);
+      if (result.updated) {
+        // Refresh local state to reflect changes
+        await refreshGoals();
+      }
+      return result;
+    } catch (err) {
+      console.error('Failed to record goal progress:', err);
+    }
+  }, [uid, refreshGoals]);
+
+  /**
+   * Claim the bonus XP when all goals are completed.
+   * Awards the XP and marks it as claimed in Firestore.
+   */
+  const claimBonusXp = useCallback(async () => {
+    if (!uid || !goalsData?.allCompleted || goalsData?.bonusXpAwarded) return;
+    try {
+      await awardXp(uid, goalsData.bonusXpAmount);
+      await markBonusXpAwarded(uid);
+      await refreshGoals();
+      return goalsData.bonusXpAmount;
+    } catch (err) {
+      console.error('Failed to claim bonus XP:', err);
+      setError(err.message);
+    }
+  }, [uid, goalsData, refreshGoals]);
+
+  // Derived state
+  const goals = goalsData?.goals || [];
+  const allCompleted = goalsData?.allCompleted || false;
+  const bonusXpAwarded = goalsData?.bonusXpAwarded || false;
+  const bonusXpAmount = goalsData?.bonusXpAmount || 0;
+
+  return useMemo(() => ({
+    goals,
+    allCompleted,
+    bonusXpAwarded,
+    bonusXpAmount,
+    loading,
+    error,
+    refreshGoals,
+    recordProgress,
+    claimBonusXp,
+    GOAL_TYPES
+  }), [goals, allCompleted, bonusXpAwarded, bonusXpAmount, loading, error, refreshGoals, recordProgress, claimBonusXp]);
+}

--- a/react-vite-app/src/services/dailyGoalsService.js
+++ b/react-vite-app/src/services/dailyGoalsService.js
@@ -1,0 +1,151 @@
+import { doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+import {
+  selectRandomGoals,
+  DAILY_GOALS_BONUS_XP,
+  DAILY_GOALS_COUNT
+} from '../utils/dailyGoalDefinitions';
+
+/**
+ * Get today's date string in YYYY-MM-DD format (user's local timezone).
+ */
+export function getTodayDateString() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Get or create daily goals for a user.
+ * If the stored goals are from a previous day (or don't exist), generate new ones.
+ *
+ * @param {string} uid
+ * @returns {Promise<object>} The daily goals document data
+ */
+export async function getOrCreateDailyGoals(uid) {
+  const today = getTodayDateString();
+  const goalsRef = doc(db, 'dailyGoals', uid);
+  const snapshot = await getDoc(goalsRef);
+
+  if (snapshot.exists()) {
+    const data = snapshot.data();
+    if (data.date === today) {
+      return data;
+    }
+  }
+
+  // Goals are stale or don't exist — generate new ones
+  const selectedGoals = selectRandomGoals(DAILY_GOALS_COUNT);
+  const goalsData = {
+    uid,
+    date: today,
+    goals: selectedGoals.map(goal => ({
+      id: goal.id,
+      description: goal.description,
+      type: goal.type,
+      target: goal.target,
+      current: 0,
+      completed: false,
+      ...(goal.isThreshold ? { isThreshold: true } : {}),
+      ...(goal.extraParams || {})
+    })),
+    allCompleted: false,
+    bonusXpAwarded: false,
+    bonusXpAmount: DAILY_GOALS_BONUS_XP,
+    createdAt: serverTimestamp(),
+    completedAt: null
+  };
+
+  await setDoc(goalsRef, goalsData);
+  return goalsData;
+}
+
+/**
+ * Record progress toward a daily goal.
+ *
+ * @param {string} uid
+ * @param {string} goalType — matches the `type` field on goal objects (from GOAL_TYPES)
+ * @param {number} value — the value to record (1 for increment, or a score for threshold)
+ * @param {object} [params] — optional params for filtering (e.g., { targetDifficulty: 'hard' })
+ * @returns {Promise<{ updated: boolean, allCompleted: boolean }>}
+ */
+export async function recordGoalProgress(uid, goalType, value = 1, params = {}) {
+  const today = getTodayDateString();
+  const goalsRef = doc(db, 'dailyGoals', uid);
+  const snapshot = await getDoc(goalsRef);
+
+  if (!snapshot.exists()) {
+    return { updated: false, allCompleted: false };
+  }
+
+  const data = snapshot.data();
+
+  // Don't update stale goals
+  if (data.date !== today) {
+    return { updated: false, allCompleted: false };
+  }
+
+  // Already all completed + bonus awarded — no further updates needed
+  if (data.allCompleted && data.bonusXpAwarded) {
+    return { updated: false, allCompleted: true };
+  }
+
+  let anyUpdated = false;
+  const updatedGoals = data.goals.map(goal => {
+    if (goal.type !== goalType) return goal;
+    if (goal.completed) return goal;
+
+    // Check extra params (e.g., targetDifficulty must match)
+    if (goal.targetDifficulty && params.targetDifficulty !== goal.targetDifficulty) {
+      return goal;
+    }
+
+    const updated = { ...goal };
+
+    if (goal.isThreshold) {
+      // Threshold: track the best single value
+      updated.current = Math.max(goal.current, value);
+    } else {
+      // Counter: accumulate
+      updated.current = goal.current + value;
+    }
+
+    if (updated.current >= goal.target) {
+      updated.completed = true;
+    }
+
+    anyUpdated = true;
+    return updated;
+  });
+
+  if (!anyUpdated) {
+    return { updated: false, allCompleted: data.allCompleted };
+  }
+
+  const allCompleted = updatedGoals.every(g => g.completed);
+
+  const updatePayload = {
+    goals: updatedGoals,
+    allCompleted,
+  };
+
+  if (allCompleted && !data.allCompleted) {
+    updatePayload.completedAt = serverTimestamp();
+  }
+
+  await updateDoc(goalsRef, updatePayload);
+
+  return {
+    updated: true,
+    allCompleted,
+  };
+}
+
+/**
+ * Mark the daily bonus XP as awarded (prevents double-award).
+ *
+ * @param {string} uid
+ * @returns {Promise<void>}
+ */
+export async function markBonusXpAwarded(uid) {
+  const goalsRef = doc(db, 'dailyGoals', uid);
+  await updateDoc(goalsRef, { bonusXpAwarded: true });
+}

--- a/react-vite-app/src/utils/dailyGoalDefinitions.js
+++ b/react-vite-app/src/utils/dailyGoalDefinitions.js
@@ -1,0 +1,164 @@
+/**
+ * Daily Goals — Goal Pool & Selection Logic
+ *
+ * Defines all possible daily goals and the function to randomly select
+ * a subset each day. Goals are predefined (not user-created).
+ */
+
+/**
+ * Goal type enum — determines which game event increments progress.
+ */
+export const GOAL_TYPES = {
+  GAMES_PLAYED: 'games_played',
+  HIGH_SCORE_ROUND: 'high_score_round',
+  HIGH_SCORE_GAME: 'high_score_game',
+  PLAY_DIFFICULTY: 'play_difficulty',
+  WIN_DUEL: 'win_duel',
+  PLAY_DUEL: 'play_duel',
+  PERFECT_FLOOR: 'perfect_floor',
+};
+
+/**
+ * Master pool of all possible daily goals.
+ *
+ * Each definition has:
+ *   id          — unique identifier
+ *   description — human-readable text shown to the user
+ *   type        — event type that triggers progress (from GOAL_TYPES)
+ *   target      — value required to complete the goal
+ *   isThreshold — if true, "current" tracks best single attempt, not cumulative
+ *   extraParams — optional params (e.g., targetDifficulty)
+ */
+export const GOAL_POOL = [
+  {
+    id: 'play_1_game',
+    description: 'Play 1 game',
+    type: GOAL_TYPES.GAMES_PLAYED,
+    target: 1,
+    isThreshold: false,
+  },
+  {
+    id: 'play_3_games',
+    description: 'Play 3 games',
+    type: GOAL_TYPES.GAMES_PLAYED,
+    target: 3,
+    isThreshold: false,
+  },
+  {
+    id: 'play_5_games',
+    description: 'Play 5 games',
+    type: GOAL_TYPES.GAMES_PLAYED,
+    target: 5,
+    isThreshold: false,
+  },
+  {
+    id: 'score_3000_round',
+    description: 'Score 3,000+ in a single round',
+    type: GOAL_TYPES.HIGH_SCORE_ROUND,
+    target: 3000,
+    isThreshold: true,
+  },
+  {
+    id: 'score_4000_round',
+    description: 'Score 4,000+ in a single round',
+    type: GOAL_TYPES.HIGH_SCORE_ROUND,
+    target: 4000,
+    isThreshold: true,
+  },
+  {
+    id: 'score_5000_round',
+    description: 'Score 5,000 in a single round',
+    type: GOAL_TYPES.HIGH_SCORE_ROUND,
+    target: 5000,
+    isThreshold: true,
+  },
+  {
+    id: 'score_15000_game',
+    description: 'Score 15,000+ total in a game',
+    type: GOAL_TYPES.HIGH_SCORE_GAME,
+    target: 15000,
+    isThreshold: true,
+  },
+  {
+    id: 'score_20000_game',
+    description: 'Score 20,000+ total in a game',
+    type: GOAL_TYPES.HIGH_SCORE_GAME,
+    target: 20000,
+    isThreshold: true,
+  },
+  {
+    id: 'play_hard',
+    description: 'Play a game on Hard difficulty',
+    type: GOAL_TYPES.PLAY_DIFFICULTY,
+    target: 1,
+    isThreshold: false,
+    extraParams: { targetDifficulty: 'hard' },
+  },
+  {
+    id: 'play_medium',
+    description: 'Play a game on Medium difficulty',
+    type: GOAL_TYPES.PLAY_DIFFICULTY,
+    target: 1,
+    isThreshold: false,
+    extraParams: { targetDifficulty: 'medium' },
+  },
+  {
+    id: 'win_duel',
+    description: 'Win a duel',
+    type: GOAL_TYPES.WIN_DUEL,
+    target: 1,
+    isThreshold: false,
+  },
+  {
+    id: 'play_duel',
+    description: 'Play a duel',
+    type: GOAL_TYPES.PLAY_DUEL,
+    target: 1,
+    isThreshold: false,
+  },
+  {
+    id: 'correct_3_floors',
+    description: 'Guess the correct floor 3 times',
+    type: GOAL_TYPES.PERFECT_FLOOR,
+    target: 3,
+    isThreshold: false,
+  },
+];
+
+/** Daily bonus XP awarded when all goals are completed */
+export const DAILY_GOALS_BONUS_XP = 2000;
+
+/** Number of goals to select per day */
+export const DAILY_GOALS_COUNT = 3;
+
+/**
+ * Select N random goals from the pool.
+ * Avoids picking two goals of the same type for variety.
+ *
+ * @param {number} count — number of goals to pick
+ * @returns {Array} — array of goal definition objects
+ */
+export function selectRandomGoals(count = DAILY_GOALS_COUNT) {
+  const shuffled = [...GOAL_POOL].sort(() => Math.random() - 0.5);
+
+  const selected = [];
+  const usedTypes = new Set();
+
+  for (const goal of shuffled) {
+    if (selected.length >= count) break;
+    if (usedTypes.has(goal.type)) continue;
+    usedTypes.add(goal.type);
+    selected.push(goal);
+  }
+
+  // If we couldn't fill with unique types, allow duplicates
+  if (selected.length < count) {
+    for (const goal of shuffled) {
+      if (selected.length >= count) break;
+      if (selected.some(s => s.id === goal.id)) continue;
+      selected.push(goal);
+    }
+  }
+
+  return selected;
+}

--- a/react-vite-app/src/utils/dailyGoalDefinitions.test.js
+++ b/react-vite-app/src/utils/dailyGoalDefinitions.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GOAL_POOL,
+  GOAL_TYPES,
+  DAILY_GOALS_COUNT,
+  DAILY_GOALS_BONUS_XP,
+  selectRandomGoals
+} from './dailyGoalDefinitions';
+
+describe('dailyGoalDefinitions', () => {
+  describe('GOAL_POOL', () => {
+    it('should have no duplicate IDs', () => {
+      const ids = GOAL_POOL.map(g => g.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('should have all required fields on every goal', () => {
+      for (const goal of GOAL_POOL) {
+        expect(goal).toHaveProperty('id');
+        expect(goal).toHaveProperty('description');
+        expect(goal).toHaveProperty('type');
+        expect(goal).toHaveProperty('target');
+        expect(typeof goal.id).toBe('string');
+        expect(typeof goal.description).toBe('string');
+        expect(typeof goal.type).toBe('string');
+        expect(typeof goal.target).toBe('number');
+        expect(goal.target).toBeGreaterThan(0);
+      }
+    });
+
+    it('should only use valid goal types', () => {
+      const validTypes = Object.values(GOAL_TYPES);
+      for (const goal of GOAL_POOL) {
+        expect(validTypes).toContain(goal.type);
+      }
+    });
+
+    it('should have enough goals in the pool', () => {
+      expect(GOAL_POOL.length).toBeGreaterThanOrEqual(DAILY_GOALS_COUNT);
+    });
+  });
+
+  describe('constants', () => {
+    it('should have a positive bonus XP amount', () => {
+      expect(DAILY_GOALS_BONUS_XP).toBeGreaterThan(0);
+    });
+
+    it('should have a positive daily goals count', () => {
+      expect(DAILY_GOALS_COUNT).toBeGreaterThan(0);
+    });
+  });
+
+  describe('selectRandomGoals', () => {
+    it('should return the default number of goals', () => {
+      const goals = selectRandomGoals();
+      expect(goals).toHaveLength(DAILY_GOALS_COUNT);
+    });
+
+    it('should return the requested number of goals', () => {
+      const goals = selectRandomGoals(2);
+      expect(goals).toHaveLength(2);
+    });
+
+    it('should return goals with unique types when possible', () => {
+      // Run multiple times to account for randomness
+      for (let i = 0; i < 20; i++) {
+        const goals = selectRandomGoals(3);
+        const types = goals.map(g => g.type);
+        const uniqueTypes = new Set(types);
+        // With 7 unique types in the pool, 3 should always have unique types
+        expect(uniqueTypes.size).toBe(3);
+      }
+    });
+
+    it('should return valid goal objects', () => {
+      const goals = selectRandomGoals();
+      for (const goal of goals) {
+        expect(goal).toHaveProperty('id');
+        expect(goal).toHaveProperty('description');
+        expect(goal).toHaveProperty('type');
+        expect(goal).toHaveProperty('target');
+      }
+    });
+
+    it('should not return more goals than requested', () => {
+      const goals = selectRandomGoals(1);
+      expect(goals).toHaveLength(1);
+    });
+
+    it('should handle requesting more goals than the pool size', () => {
+      const goals = selectRandomGoals(100);
+      // Should return at most the pool size
+      expect(goals.length).toBeLessThanOrEqual(GOAL_POOL.length);
+      // Should return at least the number of unique IDs
+      expect(goals.length).toBeGreaterThan(0);
+    });
+
+    it('should return different selections across calls (randomness)', () => {
+      const selections = new Set();
+      // Run 20 times and collect the first goal ID
+      for (let i = 0; i < 20; i++) {
+        const goals = selectRandomGoals(3);
+        selections.add(goals.map(g => g.id).sort().join(','));
+      }
+      // Should have at least 2 different combinations (very likely with random)
+      expect(selections.size).toBeGreaterThan(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a daily goals system where users receive 3 random goals each day from a pool of 13 goal types (play games, hit score thresholds, win duels, guess correct floors, play on specific difficulties)
- Goals automatically reset at midnight (client-side date check) and completing all 3 awards 2,000 bonus XP via a manual claim button in the Daily Goals panel
- Integrates goal progress tracking into both singleplayer (FinalResultsScreen) and multiplayer (DuelFinalScreen) game completion flows

### New files (6)
| File | Purpose |
|------|---------|
| `src/utils/dailyGoalDefinitions.js` | Goal pool (13 definitions), type enum, `selectRandomGoals()` |
| `src/services/dailyGoalsService.js` | Firestore CRUD for `dailyGoals/{uid}` documents |
| `src/hooks/useDailyGoals.js` | React hook for goal state, progress recording, bonus claiming |
| `src/components/DailyGoalsPanel/DailyGoalsPanel.jsx` | Full-screen panel with goal cards, progress bars, claim button |
| `src/components/DailyGoalsPanel/DailyGoalsPanel.css` | Glassmorphism card styling with amber/green accents |
| `src/utils/dailyGoalDefinitions.test.js` | Unit tests for goal pool integrity and selection logic |

### Modified files (5)
| File | Change |
|------|--------|
| `src/App.jsx` | `showDailyGoals` state, panel routing, pass `difficulty` to FinalResultsScreen |
| `src/components/TitleScreen/TitleScreen.jsx` | Amber "Daily Goals" button in top action bar |
| `src/components/TitleScreen/TitleScreen.css` | Button styles + responsive breakpoint |
| `src/components/FinalResultsScreen/FinalResultsScreen.jsx` | Record goal progress after singleplayer games |
| `src/components/DuelFinalScreen/DuelFinalScreen.jsx` | Record goal progress after duels |

## Test plan
- [ ] Verify "Daily Goals" button renders on TitleScreen and opens the panel
- [ ] Verify 3 random goals are displayed with progress bars on first visit
- [ ] Play a singleplayer game and confirm relevant goals update (games played, round scores, difficulty, floor guesses)
- [ ] Play and win a duel, confirm duel-related goals update
- [ ] Complete all 3 goals and verify "Claim Bonus XP" button appears
- [ ] Claim bonus XP and verify it's awarded (check profile XP) and button changes to "Claimed"
- [ ] Refresh the page — goals should persist for the same day
- [ ] Verify goals reset when the date changes (simulate by clearing Firestore doc)
- [ ] Run `npx vitest run` — all 763 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)