### PR TITLE
Fix spacebar shortcut to place marker at cursor position

### DIFF
--- a/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
+++ b/react-vite-app/src/components/DuelGameScreen/DuelGameScreen.jsx
@@ -35,14 +35,13 @@ function DuelGameScreen({
   const handleKeyDown = useCallback((e) => {
     if (hasSubmitted) return;
 
-    // Spacebar: submit guess if ready, otherwise place marker at map center
+    // Spacebar: submit guess if ready, otherwise click at cursor position on map
     if (e.code === 'Space') {
       e.preventDefault();
       if (canSubmit) {
         onSubmitGuess();
       } else if (!guessLocation && mapPickerRef.current) {
-        const center = mapPickerRef.current.getViewportCenter();
-        onMapClick(center);
+        mapPickerRef.current.clickAtCursor();
       }
       return;
     }
@@ -55,7 +54,7 @@ function DuelGameScreen({
         onFloorSelect(digit);
       }
     }
-  }, [hasSubmitted, canSubmit, onSubmitGuess, guessLocation, onMapClick, isInRegion, availableFloors, onFloorSelect]);
+  }, [hasSubmitted, canSubmit, onSubmitGuess, guessLocation, isInRegion, availableFloors, onFloorSelect]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/react-vite-app/src/components/GameScreen/GameScreen.jsx
+++ b/react-vite-app/src/components/GameScreen/GameScreen.jsx
@@ -30,14 +30,13 @@ function GameScreen({
   const canSubmit = guessLocation !== null && (!isInRegion || guessFloor !== null);
 
   const handleKeyDown = useCallback((e) => {
-    // Spacebar: submit guess if ready, otherwise place marker at map center
+    // Spacebar: submit guess if ready, otherwise click at cursor position on map
     if (e.code === 'Space') {
       e.preventDefault();
       if (canSubmit) {
         onSubmitGuess();
       } else if (!guessLocation && mapPickerRef.current) {
-        const center = mapPickerRef.current.getViewportCenter();
-        onMapClick(center);
+        mapPickerRef.current.clickAtCursor();
       }
       return;
     }
@@ -50,7 +49,7 @@ function GameScreen({
         onFloorSelect(digit);
       }
     }
-  }, [canSubmit, onSubmitGuess, guessLocation, onMapClick, isInRegion, availableFloors, onFloorSelect]);
+  }, [canSubmit, onSubmitGuess, guessLocation, isInRegion, availableFloors, onFloorSelect]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Summary
- Spacebar now places a marker at the **current cursor position** on the map (acts as a left-click), instead of the viewport center
- Tracks mouse position via a ref in MapPicker, exposed through `clickAtCursor()`
- Extracts coordinate math into shared `coordsFromClientPos` helper

## Test plan
- [ ] Hover over a spot on the map and press spacebar — marker should appear at cursor
- [ ] Move cursor off the map and press spacebar — nothing should happen
- [ ] Once guess is complete (location + floor if needed), spacebar still submits
- [ ] Number keys still select floors when floor selector is visible
- [ ] Verify same behavior in duel mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)