### PR TITLE
Add bug reporting system to main menu

### DIFF
--- a/react-vite-app/src/App.jsx
+++ b/react-vite-app/src/App.jsx
@@ -21,6 +21,7 @@ import LeaderboardScreen from './components/LeaderboardScreen/LeaderboardScreen'
 import SubmissionApp from './components/SubmissionApp/SubmissionApp';
 import FriendsPanel from './components/FriendsPanel/FriendsPanel';
 import ChatWindow from './components/ChatWindow/ChatWindow';
+import BugReportModal from './components/BugReportModal/BugReportModal';
 import MessageBanner from './components/MessageBanner/MessageBanner';
 import EmailVerificationBanner from './components/EmailVerificationBanner/EmailVerificationBanner';
 import './App.css';
@@ -33,6 +34,7 @@ function App() {
   const [showChat, setShowChat] = useState(false);
   const [chatFriend, setChatFriend] = useState(null); // { uid, username }
   const [showLeaderboard, setShowLeaderboard] = useState(false);
+  const [showBugReport, setShowBugReport] = useState(false);
 
   // Track whether we're in a duel (multiplayer) game
   const [inDuel, setInDuel] = useState(false);
@@ -290,6 +292,7 @@ function App() {
           onOpenProfile={() => setShowProfile(true)}
           onOpenFriends={() => setShowFriends(true)}
           onOpenLeaderboard={() => setShowLeaderboard(true)}
+          onOpenBugReport={() => setShowBugReport(true)}
           isLoading={isLoading}
         />
       )}
@@ -450,6 +453,16 @@ function App() {
         <div className="loading-container">
           <div className="loading-spinner"></div>
         </div>
+      )}
+
+      {/* Bug Report Modal (renders as portal overlay) */}
+      {showBugReport && (
+        <BugReportModal
+          onClose={() => setShowBugReport(false)}
+          userId={user.uid}
+          username={userDoc?.username}
+          userEmail={user.email}
+        />
       )}
     </div>
   );

--- a/react-vite-app/src/components/BugReportModal/BugReportModal.css
+++ b/react-vite-app/src/components/BugReportModal/BugReportModal.css
@@ -1,0 +1,678 @@
+/* ===== Bug Report Modal - Dark Glass Theme ===== */
+
+/* Overlay */
+.bug-report-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  animation: bugReportOverlayIn 0.2s ease-out;
+}
+
+@keyframes bugReportOverlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Content card */
+.bug-report-content {
+  background: linear-gradient(145deg, #1e1e3a 0%, #161630 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  max-width: 560px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 32px;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5), 0 0 40px rgba(251, 146, 60, 0.06);
+  animation: bugReportSlideIn 0.3s ease-out;
+}
+
+@keyframes bugReportSlideIn {
+  from { opacity: 0; transform: translateY(20px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Scrollbar styling */
+.bug-report-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.bug-report-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bug-report-content::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.bug-report-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* Close button */
+.bug-report-close {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #8892a8;
+  line-height: 1;
+  padding: 6px 10px;
+  border-radius: 10px;
+  transition: all 0.2s ease;
+  z-index: 1;
+}
+
+.bug-report-close:hover {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.15);
+}
+
+/* Title */
+.bug-report-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: #e0e6f0;
+  margin: 0 0 20px 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bug-report-title-icon {
+  font-size: 24px;
+}
+
+/* ===== Tabs ===== */
+.bug-report-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 20px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.bug-report-tab {
+  flex: 1;
+  padding: 10px 16px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: #8892a8;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.bug-report-tab:hover {
+  color: #c4c9d6;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.bug-report-tab.active {
+  background: linear-gradient(135deg, rgba(251, 146, 60, 0.15) 0%, rgba(251, 191, 36, 0.1) 100%);
+  color: #fb923c;
+  box-shadow: 0 2px 8px rgba(251, 146, 60, 0.12);
+}
+
+/* ===== Error & Success Messages ===== */
+.bug-report-error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #f87171;
+  padding: 12px 16px;
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+.bug-report-success {
+  background: rgba(52, 211, 153, 0.1);
+  color: #34d399;
+  padding: 12px 16px;
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  font-weight: 600;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ===== Form Layout ===== */
+.bug-report-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Field wrapper */
+.bug-report-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Label */
+.bug-report-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: #8892a8;
+}
+
+.bug-report-required {
+  color: #f87171;
+  margin-left: 2px;
+}
+
+/* Text input */
+.bug-report-input {
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.bug-report-input:focus {
+  outline: none;
+  border-color: rgba(251, 146, 60, 0.5);
+  box-shadow: 0 0 0 3px rgba(251, 146, 60, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.bug-report-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bug-report-input::placeholder {
+  color: #4a5568;
+}
+
+/* Select dropdown */
+.bug-report-select {
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238892a8' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  padding-right: 36px;
+}
+
+.bug-report-select:focus {
+  outline: none;
+  border-color: rgba(251, 146, 60, 0.5);
+  box-shadow: 0 0 0 3px rgba(251, 146, 60, 0.1);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.bug-report-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bug-report-select option {
+  background: #1e1e3a;
+  color: #e0e6f0;
+}
+
+/* Textarea */
+.bug-report-textarea {
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 80px;
+  line-height: 1.5;
+}
+
+.bug-report-textarea:focus {
+  outline: none;
+  border-color: rgba(251, 146, 60, 0.5);
+  box-shadow: 0 0 0 3px rgba(251, 146, 60, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.bug-report-textarea:disabled {
+  opacity: 0.5;
+  background: rgba(255, 255, 255, 0.02);
+  cursor: not-allowed;
+}
+
+.bug-report-textarea::placeholder {
+  color: #4a5568;
+}
+
+/* Character count */
+.bug-report-char-count {
+  font-size: 11px;
+  color: #6b7280;
+  text-align: right;
+}
+
+.bug-report-char-count.warning {
+  color: #fbbf24;
+}
+
+.bug-report-char-count.danger {
+  color: #f87171;
+}
+
+/* ===== Severity Button Group ===== */
+.bug-report-severity-group {
+  display: flex;
+  gap: 8px;
+}
+
+.bug-report-severity-btn {
+  flex: 1;
+  padding: 10px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #8892a8;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.bug-report-severity-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bug-report-severity-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Severity colors when selected */
+.bug-report-severity-btn.severity-low.selected {
+  background: rgba(96, 165, 250, 0.15);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: #60a5fa;
+  box-shadow: 0 2px 8px rgba(96, 165, 250, 0.15);
+}
+
+.bug-report-severity-btn.severity-medium.selected {
+  background: rgba(251, 191, 36, 0.15);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: #fbbf24;
+  box-shadow: 0 2px 8px rgba(251, 191, 36, 0.15);
+}
+
+.bug-report-severity-btn.severity-high.selected {
+  background: rgba(251, 146, 60, 0.15);
+  border-color: rgba(251, 146, 60, 0.4);
+  color: #fb923c;
+  box-shadow: 0 2px 8px rgba(251, 146, 60, 0.15);
+}
+
+.bug-report-severity-btn.severity-critical.selected {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #f87171;
+  box-shadow: 0 2px 8px rgba(248, 113, 113, 0.15);
+}
+
+/* ===== Screenshot Upload ===== */
+.bug-report-screenshot-area {
+  border: 2px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.bug-report-screenshot-area:hover {
+  border-color: rgba(251, 146, 60, 0.3);
+  background: rgba(251, 146, 60, 0.04);
+}
+
+.bug-report-screenshot-area.has-image {
+  border-style: solid;
+  border-color: rgba(52, 211, 153, 0.3);
+  background: rgba(52, 211, 153, 0.04);
+  padding: 12px;
+}
+
+.bug-report-screenshot-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.bug-report-screenshot-icon {
+  font-size: 28px;
+  opacity: 0.6;
+}
+
+.bug-report-screenshot-text {
+  font-size: 13px;
+  color: #8892a8;
+}
+
+.bug-report-screenshot-hint {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.bug-report-screenshot-preview {
+  position: relative;
+  display: inline-block;
+}
+
+.bug-report-screenshot-preview img {
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 8px;
+  display: block;
+}
+
+.bug-report-screenshot-remove {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(248, 113, 113, 0.9);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  line-height: 1;
+}
+
+.bug-report-screenshot-remove:hover {
+  background: #f87171;
+  transform: scale(1.1);
+}
+
+.bug-report-screenshot-file-input {
+  display: none;
+}
+
+/* ===== Action Buttons ===== */
+.bug-report-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.bug-report-submit {
+  flex: 1;
+  padding: 13px;
+  background: linear-gradient(135deg, #fb923c 0%, #f97316 100%);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 15px rgba(251, 146, 60, 0.3);
+}
+
+.bug-report-submit:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(251, 146, 60, 0.4);
+}
+
+.bug-report-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.bug-report-cancel {
+  flex: 1;
+  padding: 13px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #b0b8cc;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.bug-report-cancel:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.bug-report-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===== My Reports Tab ===== */
+.bug-report-history {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bug-report-history-loading {
+  text-align: center;
+  padding: 40px 20px;
+  color: #8892a8;
+  font-size: 14px;
+}
+
+.bug-report-history-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.bug-report-history-empty-icon {
+  font-size: 36px;
+  display: block;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+
+.bug-report-history-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 16px;
+  transition: all 0.2s ease;
+}
+
+.bug-report-history-card:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.bug-report-history-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.bug-report-history-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e0e6f0;
+  flex: 1;
+  line-height: 1.3;
+}
+
+.bug-report-history-card-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.bug-report-history-card-description {
+  font-size: 13px;
+  color: #8892a8;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.bug-report-history-card-date {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+/* ===== Badges ===== */
+.bug-report-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+/* Status badges */
+.bug-report-badge.status-open {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-report-badge.status-in-progress {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-report-badge.status-resolved {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+}
+
+.bug-report-badge.status-wont-fix {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+.bug-report-badge.status-closed {
+  background: rgba(136, 146, 168, 0.12);
+  color: #8892a8;
+}
+
+/* Severity badges */
+.bug-report-badge.severity-low {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-report-badge.severity-medium {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-report-badge.severity-high {
+  background: rgba(251, 146, 60, 0.12);
+  color: #fb923c;
+}
+
+.bug-report-badge.severity-critical {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+/* Category badges */
+.bug-report-badge.category {
+  background: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 480px) {
+  .bug-report-content {
+    padding: 22px;
+    margin: 10px;
+    border-radius: 20px;
+  }
+
+  .bug-report-title {
+    font-size: 18px;
+  }
+
+  .bug-report-actions {
+    flex-direction: column;
+  }
+
+  .bug-report-severity-group {
+    flex-wrap: wrap;
+  }
+
+  .bug-report-severity-btn {
+    flex: 1 1 calc(50% - 4px);
+  }
+
+  .bug-report-tabs {
+    border-radius: 10px;
+  }
+
+  .bug-report-tab {
+    font-size: 12px;
+    padding: 8px 12px;
+  }
+}

--- a/react-vite-app/src/components/BugReportModal/BugReportModal.jsx
+++ b/react-vite-app/src/components/BugReportModal/BugReportModal.jsx
@@ -1,0 +1,478 @@
+import { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  submitBugReport,
+  getBugReportsByUser,
+  captureEnvironment,
+  VALID_CATEGORIES,
+  VALID_SEVERITIES
+} from '../../services/bugReportService'
+import { compressImage } from '../../utils/compressImage'
+import './BugReportModal.css'
+
+const CATEGORY_LABELS = {
+  gameplay: 'Gameplay',
+  ui: 'UI / Visual',
+  performance: 'Performance',
+  map: 'Map / Location',
+  multiplayer: 'Multiplayer',
+  other: 'Other'
+}
+
+const SEVERITY_LABELS = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical'
+}
+
+/**
+ * Format a Firestore timestamp or ISO string for display.
+ */
+function formatDate(timestamp) {
+  if (!timestamp) return 'N/A'
+  const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+}
+
+/**
+ * Bug Report Modal — user-facing modal for submitting bug reports
+ * and viewing report history.
+ *
+ * @param {{ onClose: function, userId: string, username: string, userEmail: string }} props
+ */
+function BugReportModal({ onClose, userId, username, userEmail }) {
+  const [activeTab, setActiveTab] = useState('submit')
+
+  // ── Submit tab state ──
+  const [title, setTitle] = useState('')
+  const [category, setCategory] = useState('')
+  const [severity, setSeverity] = useState('')
+  const [description, setDescription] = useState('')
+  const [stepsToReproduce, setStepsToReproduce] = useState('')
+  const [screenshot, setScreenshot] = useState(null) // compressed base64
+  const [screenshotPreview, setScreenshotPreview] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(false)
+
+  // ── History tab state ──
+  const [reports, setReports] = useState([])
+  const [loadingReports, setLoadingReports] = useState(false)
+  const [reportsError, setReportsError] = useState(null)
+  const [historyLoaded, setHistoryLoaded] = useState(false)
+
+  const fileInputRef = useRef(null)
+
+  // Load reports when switching to history tab
+  useEffect(() => {
+    if (activeTab !== 'history' || historyLoaded) return
+
+    let cancelled = false
+    setLoadingReports(true)
+    setReportsError(null)
+
+    getBugReportsByUser(userId)
+      .then((userReports) => {
+        if (!cancelled) {
+          setReports(userReports)
+          setHistoryLoaded(true)
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load bug reports:', err)
+        if (!cancelled) {
+          setReportsError('Failed to load your reports.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingReports(false)
+        }
+      })
+
+    return () => { cancelled = true }
+  }, [activeTab, historyLoaded, userId])
+
+  const handleScreenshotSelect = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    // Validate file type
+    if (!file.type.startsWith('image/')) {
+      setError('Please select an image file.')
+      return
+    }
+
+    // Validate file size (max 10MB before compression)
+    if (file.size > 10 * 1024 * 1024) {
+      setError('Image file is too large (max 10MB).')
+      return
+    }
+
+    try {
+      const compressed = await compressImage(file, {
+        maxWidth: 600,
+        maxHeight: 600,
+        quality: 0.6
+      })
+
+      // Check compressed size (Firestore doc limit is 1MB, leave room for other fields)
+      if (compressed.length > 500_000) {
+        setError('Compressed image is too large. Please use a smaller image.')
+        return
+      }
+
+      setScreenshot(compressed)
+      setScreenshotPreview(compressed)
+      setError(null)
+    } catch (err) {
+      console.error('Failed to compress image:', err)
+      setError('Failed to process the image. Please try another.')
+    }
+  }
+
+  const handleRemoveScreenshot = () => {
+    setScreenshot(null)
+    setScreenshotPreview(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+
+    // Client-side validation
+    if (!title.trim()) {
+      setError('Please enter a title for your bug report.')
+      return
+    }
+    if (!category) {
+      setError('Please select a category.')
+      return
+    }
+    if (!severity) {
+      setError('Please select a severity level.')
+      return
+    }
+    if (!description.trim()) {
+      setError('Please provide a description of the bug.')
+      return
+    }
+
+    try {
+      setSubmitting(true)
+      await submitBugReport({
+        userId,
+        username,
+        userEmail,
+        title: title.trim(),
+        category,
+        severity,
+        description: description.trim(),
+        stepsToReproduce: stepsToReproduce.trim(),
+        screenshot,
+        environment: captureEnvironment()
+      })
+
+      setSuccess(true)
+      // Reset form for next time
+      setHistoryLoaded(false)
+
+      // Auto-close after 2 seconds
+      setTimeout(() => {
+        onClose()
+      }, 2000)
+    } catch (err) {
+      console.error('Failed to submit bug report:', err)
+      setError(err.message || 'Failed to submit bug report. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const getCharCountClass = (current, max) => {
+    const ratio = current / max
+    if (ratio >= 0.95) return 'bug-report-char-count danger'
+    if (ratio >= 0.8) return 'bug-report-char-count warning'
+    return 'bug-report-char-count'
+  }
+
+  const isFormValid = title.trim() && category && severity && description.trim()
+
+  return createPortal(
+    <div className="bug-report-overlay" onClick={onClose}>
+      <div className="bug-report-content" onClick={e => e.stopPropagation()}>
+        <button className="bug-report-close" onClick={onClose}>&times;</button>
+
+        <h3 className="bug-report-title">
+          <span className="bug-report-title-icon">🐛</span>
+          Report a Bug
+        </h3>
+
+        {/* Tab switcher */}
+        <div className="bug-report-tabs">
+          <button
+            className={`bug-report-tab ${activeTab === 'submit' ? 'active' : ''}`}
+            onClick={() => setActiveTab('submit')}
+          >
+            Submit Report
+          </button>
+          <button
+            className={`bug-report-tab ${activeTab === 'history' ? 'active' : ''}`}
+            onClick={() => setActiveTab('history')}
+          >
+            My Reports
+          </button>
+        </div>
+
+        {/* ─── Submit Report Tab ─── */}
+        {activeTab === 'submit' && (
+          <>
+            {error && <div className="bug-report-error">{error}</div>}
+            {success && (
+              <div className="bug-report-success">
+                Bug report submitted! Thank you for your feedback.
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="bug-report-form">
+              {/* Title */}
+              <div className="bug-report-field">
+                <label className="bug-report-label" htmlFor="bug-title">
+                  Title <span className="bug-report-required">*</span>
+                </label>
+                <input
+                  id="bug-title"
+                  type="text"
+                  className="bug-report-input"
+                  value={title}
+                  onChange={(e) => {
+                    setTitle(e.target.value)
+                    setError(null)
+                  }}
+                  placeholder="Brief summary of the bug..."
+                  disabled={submitting || success}
+                  maxLength={100}
+                />
+                <span className={getCharCountClass(title.length, 100)}>
+                  {title.length}/100
+                </span>
+              </div>
+
+              {/* Category */}
+              <div className="bug-report-field">
+                <label className="bug-report-label" htmlFor="bug-category">
+                  Category <span className="bug-report-required">*</span>
+                </label>
+                <select
+                  id="bug-category"
+                  className="bug-report-select"
+                  value={category}
+                  onChange={(e) => {
+                    setCategory(e.target.value)
+                    setError(null)
+                  }}
+                  disabled={submitting || success}
+                >
+                  <option value="">Select a category...</option>
+                  {VALID_CATEGORIES.map(cat => (
+                    <option key={cat} value={cat}>{CATEGORY_LABELS[cat]}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Severity */}
+              <div className="bug-report-field">
+                <label className="bug-report-label">
+                  Severity <span className="bug-report-required">*</span>
+                </label>
+                <div className="bug-report-severity-group">
+                  {VALID_SEVERITIES.map(sev => (
+                    <button
+                      key={sev}
+                      type="button"
+                      className={`bug-report-severity-btn severity-${sev} ${severity === sev ? 'selected' : ''}`}
+                      onClick={() => {
+                        setSeverity(sev)
+                        setError(null)
+                      }}
+                      disabled={submitting || success}
+                    >
+                      {SEVERITY_LABELS[sev]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Description */}
+              <div className="bug-report-field">
+                <label className="bug-report-label" htmlFor="bug-description">
+                  Description <span className="bug-report-required">*</span>
+                </label>
+                <textarea
+                  id="bug-description"
+                  className="bug-report-textarea"
+                  value={description}
+                  onChange={(e) => {
+                    setDescription(e.target.value)
+                    setError(null)
+                  }}
+                  placeholder="Describe what happened, what you expected, and what actually occurred..."
+                  disabled={submitting || success}
+                  rows={4}
+                  maxLength={2000}
+                />
+                <span className={getCharCountClass(description.length, 2000)}>
+                  {description.length}/2000
+                </span>
+              </div>
+
+              {/* Steps to Reproduce */}
+              <div className="bug-report-field">
+                <label className="bug-report-label" htmlFor="bug-steps">
+                  Steps to Reproduce <span style={{ fontSize: '10px', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+                </label>
+                <textarea
+                  id="bug-steps"
+                  className="bug-report-textarea"
+                  value={stepsToReproduce}
+                  onChange={(e) => setStepsToReproduce(e.target.value)}
+                  placeholder="1. Go to...&#10;2. Click on...&#10;3. See error..."
+                  disabled={submitting || success}
+                  rows={3}
+                  maxLength={1000}
+                />
+                <span className={getCharCountClass(stepsToReproduce.length, 1000)}>
+                  {stepsToReproduce.length}/1000
+                </span>
+              </div>
+
+              {/* Screenshot */}
+              <div className="bug-report-field">
+                <label className="bug-report-label">
+                  Screenshot <span style={{ fontSize: '10px', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>(optional)</span>
+                </label>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="bug-report-screenshot-file-input"
+                  onChange={handleScreenshotSelect}
+                  disabled={submitting || success}
+                />
+                {screenshotPreview ? (
+                  <div className="bug-report-screenshot-area has-image">
+                    <div className="bug-report-screenshot-preview">
+                      <img src={screenshotPreview} alt="Screenshot preview" />
+                      <button
+                        type="button"
+                        className="bug-report-screenshot-remove"
+                        onClick={handleRemoveScreenshot}
+                        disabled={submitting || success}
+                        title="Remove screenshot"
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div
+                    className="bug-report-screenshot-area"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <div className="bug-report-screenshot-placeholder">
+                      <span className="bug-report-screenshot-icon">📷</span>
+                      <span className="bug-report-screenshot-text">Click to attach a screenshot</span>
+                      <span className="bug-report-screenshot-hint">PNG, JPG, or GIF up to 10MB</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="bug-report-actions">
+                <button
+                  type="submit"
+                  className="bug-report-submit"
+                  disabled={submitting || success || !isFormValid}
+                >
+                  {submitting ? 'Submitting...' : success ? 'Submitted!' : 'Submit Report'}
+                </button>
+                <button
+                  type="button"
+                  className="bug-report-cancel"
+                  onClick={onClose}
+                  disabled={submitting}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+
+        {/* ─── My Reports Tab ─── */}
+        {activeTab === 'history' && (
+          <div className="bug-report-history">
+            {loadingReports && (
+              <div className="bug-report-history-loading">Loading your reports...</div>
+            )}
+
+            {reportsError && (
+              <div className="bug-report-error">{reportsError}</div>
+            )}
+
+            {!loadingReports && !reportsError && reports.length === 0 && (
+              <div className="bug-report-history-empty">
+                <span className="bug-report-history-empty-icon">📋</span>
+                You haven&apos;t submitted any bug reports yet.
+              </div>
+            )}
+
+            {!loadingReports && reports.map(report => (
+              <div key={report.id} className="bug-report-history-card">
+                <div className="bug-report-history-card-header">
+                  <span className="bug-report-history-card-title">{report.title}</span>
+                  <div className="bug-report-history-card-badges">
+                    <span className={`bug-report-badge status-${report.status}`}>
+                      {report.status === 'wont-fix' ? "Won't Fix" : report.status.replace('-', ' ')}
+                    </span>
+                    <span className={`bug-report-badge severity-${report.severity}`}>
+                      {report.severity}
+                    </span>
+                  </div>
+                </div>
+                <div className="bug-report-history-card-description">
+                  {report.description}
+                </div>
+                <div className="bug-report-history-card-badges" style={{ marginBottom: 6 }}>
+                  <span className="bug-report-badge category">
+                    {CATEGORY_LABELS[report.category] || report.category}
+                  </span>
+                </div>
+                <div className="bug-report-history-card-date">
+                  Submitted {formatDate(report.createdAt)}
+                  {report.adminNotes?.length > 0 && (
+                    <span> &middot; {report.adminNotes.length} admin note{report.adminNotes.length !== 1 ? 's' : ''}</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default BugReportModal

--- a/react-vite-app/src/components/BugReportModal/BugReportModal.test.jsx
+++ b/react-vite-app/src/components/BugReportModal/BugReportModal.test.jsx
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BugReportModal from './BugReportModal';
+
+// Mock Firebase
+vi.mock('../../firebase', () => ({
+  db: {},
+  app: {},
+  auth: {}
+}));
+
+// Mock bugReportService
+vi.mock('../../services/bugReportService', () => ({
+  submitBugReport: vi.fn(),
+  getBugReportsByUser: vi.fn(),
+  captureEnvironment: vi.fn(() => ({
+    userAgent: 'test-agent',
+    platform: 'test-platform',
+    language: 'en',
+    screenWidth: 1920,
+    screenHeight: 1080,
+    windowWidth: 1920,
+    windowHeight: 1080,
+    timestamp: '2024-01-01T00:00:00.000Z'
+  })),
+  VALID_CATEGORIES: ['gameplay', 'ui', 'performance', 'map', 'multiplayer', 'other'],
+  VALID_SEVERITIES: ['low', 'medium', 'high', 'critical']
+}));
+
+// Mock compressImage
+vi.mock('../../utils/compressImage', () => ({
+  compressImage: vi.fn()
+}));
+
+import { submitBugReport, getBugReportsByUser } from '../../services/bugReportService';
+
+describe('BugReportModal', () => {
+  const defaultProps = {
+    onClose: vi.fn(),
+    userId: 'test-uid',
+    username: 'TestUser',
+    userEmail: 'test@example.com'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBugReportsByUser.mockResolvedValue([]);
+  });
+
+  // Helper to get form fields by their id attributes
+  const getTitleInput = () => document.getElementById('bug-title');
+  const getCategorySelect = () => document.getElementById('bug-category');
+  const getDescriptionTextarea = () => document.getElementById('bug-description');
+  const getStepsTextarea = () => document.getElementById('bug-steps');
+  const getSubmitButton = () => document.querySelector('.bug-report-submit');
+
+  describe('rendering', () => {
+    it('should render the modal title', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText('Report a Bug')).toBeInTheDocument();
+    });
+
+    it('should render the bug icon', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText('🐛')).toBeInTheDocument();
+    });
+
+    it('should render Submit Report and My Reports tabs', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      // "Submit Report" appears in both the tab and the submit button
+      const submitReportElements = screen.getAllByText('Submit Report');
+      expect(submitReportElements.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('My Reports')).toBeInTheDocument();
+    });
+
+    it('should render the close button', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText('×')).toBeInTheDocument();
+    });
+  });
+
+  describe('submit form fields', () => {
+    it('should render title input', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getTitleInput()).toBeInTheDocument();
+    });
+
+    it('should render category select', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getCategorySelect()).toBeInTheDocument();
+    });
+
+    it('should render severity buttons', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText('Low')).toBeInTheDocument();
+      expect(screen.getByText('Medium')).toBeInTheDocument();
+      expect(screen.getByText('High')).toBeInTheDocument();
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+    });
+
+    it('should render description textarea', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getDescriptionTextarea()).toBeInTheDocument();
+    });
+
+    it('should render steps to reproduce textarea', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getStepsTextarea()).toBeInTheDocument();
+    });
+
+    it('should render screenshot upload area', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText(/click to attach a screenshot/i)).toBeInTheDocument();
+    });
+
+    it('should render submit and cancel buttons', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getSubmitButton()).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('should render character counts', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(screen.getByText('0/100')).toBeInTheDocument();
+      expect(screen.getByText('0/2000')).toBeInTheDocument();
+      expect(screen.getByText('0/1000')).toBeInTheDocument();
+    });
+  });
+
+  describe('form interactions', () => {
+    it('should update title character count when typing', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      const titleInput = getTitleInput();
+      await user.type(titleInput, 'Test bug');
+
+      expect(screen.getByText('8/100')).toBeInTheDocument();
+    });
+
+    it('should select severity when clicking a severity button', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      const highButton = screen.getByText('High');
+      await user.click(highButton);
+
+      expect(highButton).toHaveClass('selected');
+    });
+
+    it('should have submit button disabled when form is incomplete', () => {
+      render(<BugReportModal {...defaultProps} />);
+
+      expect(getSubmitButton()).toBeDisabled();
+    });
+  });
+
+  describe('form submission', () => {
+    it('should show error if title is empty on submit', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      // Fill in everything except title
+      await user.selectOptions(getCategorySelect(), 'gameplay');
+      await user.click(screen.getByText('High'));
+      await user.type(getDescriptionTextarea(), 'A description');
+
+      // The submit button should still be disabled because title is empty
+      expect(getSubmitButton()).toBeDisabled();
+    });
+
+    it('should call submitBugReport when form is valid and submitted', async () => {
+      const user = userEvent.setup();
+      submitBugReport.mockResolvedValueOnce('new-report-id');
+
+      render(<BugReportModal {...defaultProps} />);
+
+      // Fill in all required fields
+      await user.type(getTitleInput(), 'Test Bug Title');
+      await user.selectOptions(getCategorySelect(), 'gameplay');
+      await user.click(screen.getByText('High'));
+      await user.type(getDescriptionTextarea(), 'Bug description here');
+
+      // Find and click the submit button
+      await user.click(getSubmitButton());
+
+      expect(submitBugReport).toHaveBeenCalledTimes(1);
+      expect(submitBugReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'test-uid',
+          username: 'TestUser',
+          title: 'Test Bug Title',
+          category: 'gameplay',
+          severity: 'high',
+          description: 'Bug description here'
+        })
+      );
+    });
+
+    it('should show success message after successful submission', async () => {
+      const user = userEvent.setup();
+      submitBugReport.mockResolvedValueOnce('new-report-id');
+
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(getTitleInput(), 'Test Bug');
+      await user.selectOptions(getCategorySelect(), 'ui');
+      await user.click(screen.getByText('Low'));
+      await user.type(getDescriptionTextarea(), 'Description');
+
+      await user.click(getSubmitButton());
+
+      expect(screen.getByText(/bug report submitted/i)).toBeInTheDocument();
+    });
+
+    it('should show error message on submission failure', async () => {
+      const user = userEvent.setup();
+      submitBugReport.mockRejectedValueOnce(new Error('Rate limit exceeded'));
+
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.type(getTitleInput(), 'Test Bug');
+      await user.selectOptions(getCategorySelect(), 'ui');
+      await user.click(screen.getByText('Low'));
+      await user.type(getDescriptionTextarea(), 'Description');
+
+      await user.click(getSubmitButton());
+
+      expect(screen.getByText('Rate limit exceeded')).toBeInTheDocument();
+    });
+  });
+
+  describe('close behavior', () => {
+    it('should call onClose when close button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.click(screen.getByText('×'));
+
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.click(screen.getByText('Cancel'));
+
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('My Reports tab', () => {
+    it('should switch to My Reports tab when clicked', async () => {
+      const user = userEvent.setup();
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.click(screen.getByText('My Reports'));
+
+      expect(getBugReportsByUser).toHaveBeenCalledWith('test-uid');
+    });
+
+    it('should show empty state when no reports exist', async () => {
+      const user = userEvent.setup();
+      getBugReportsByUser.mockResolvedValueOnce([]);
+
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.click(screen.getByText('My Reports'));
+
+      // Wait for loading to complete
+      expect(await screen.findByText(/haven't submitted any bug reports/i)).toBeInTheDocument();
+    });
+
+    it('should display report cards when reports exist', async () => {
+      const user = userEvent.setup();
+      getBugReportsByUser.mockResolvedValueOnce([
+        {
+          id: 'report-1',
+          title: 'Test Bug Report',
+          status: 'open',
+          severity: 'high',
+          category: 'gameplay',
+          description: 'A test description',
+          createdAt: { toDate: () => new Date('2024-06-15') },
+          adminNotes: []
+        }
+      ]);
+
+      render(<BugReportModal {...defaultProps} />);
+
+      await user.click(screen.getByText('My Reports'));
+
+      expect(await screen.findByText('Test Bug Report')).toBeInTheDocument();
+    });
+  });
+});

--- a/react-vite-app/src/components/SubmissionApp/AdminTabs.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminTabs.jsx
@@ -3,6 +3,7 @@ import AdminReview from './AdminReview'
 import MapEditor from './MapEditor'
 import AccountManagement from './AccountManagement'
 import FriendsManagement from './FriendsManagement'
+import BugReportManagement from './BugReportManagement'
 
 function AdminTabs({ activeTab, onTabChange, onBack }) {
   return (
@@ -39,6 +40,12 @@ function AdminTabs({ activeTab, onTabChange, onBack }) {
         >
           Friends &amp; Chat
         </button>
+        <button
+          className={`admin-tab ${activeTab === 'bugReports' ? 'active' : ''}`}
+          onClick={() => onTabChange('bugReports')}
+        >
+          Bug Reports
+        </button>
       </div>
 
       <div className="admin-content">
@@ -46,6 +53,7 @@ function AdminTabs({ activeTab, onTabChange, onBack }) {
         {activeTab === 'mapEditor' && <MapEditor />}
         {activeTab === 'accounts' && <AccountManagement />}
         {activeTab === 'friends' && <FriendsManagement />}
+        {activeTab === 'bugReports' && <BugReportManagement />}
       </div>
     </div>
   )

--- a/react-vite-app/src/components/SubmissionApp/AdminTabs.test.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminTabs.test.jsx
@@ -20,6 +20,10 @@ vi.mock('./FriendsManagement', () => ({
   default: () => <div data-testid="friends-management">Friends Management Component</div>
 }));
 
+vi.mock('./BugReportManagement', () => ({
+  default: () => <div data-testid="bug-report-management">Bug Report Management Component</div>
+}));
+
 describe('AdminTabs', () => {
   const mockOnTabChange = vi.fn();
   const mockOnBack = vi.fn();
@@ -55,6 +59,13 @@ describe('AdminTabs', () => {
         <AdminTabs activeTab="review" onTabChange={mockOnTabChange} onBack={mockOnBack} />
       );
       expect(screen.getByText('Map Editor')).toBeInTheDocument();
+    });
+
+    it('should render Bug Reports tab', () => {
+      render(
+        <AdminTabs activeTab="review" onTabChange={mockOnTabChange} onBack={mockOnBack} />
+      );
+      expect(screen.getByText('Bug Reports')).toBeInTheDocument();
     });
   });
 
@@ -98,6 +109,22 @@ describe('AdminTabs', () => {
       const reviewTab = screen.getByText('Review Submissions');
       expect(reviewTab).not.toHaveClass('active');
     });
+
+    it('should show BugReportManagement when activeTab is bugReports', () => {
+      render(
+        <AdminTabs activeTab="bugReports" onTabChange={mockOnTabChange} onBack={mockOnBack} />
+      );
+      expect(screen.getByTestId('bug-report-management')).toBeInTheDocument();
+      expect(screen.queryByTestId('admin-review')).not.toBeInTheDocument();
+    });
+
+    it('should have active class on Bug Reports tab when activeTab is bugReports', () => {
+      render(
+        <AdminTabs activeTab="bugReports" onTabChange={mockOnTabChange} onBack={mockOnBack} />
+      );
+      const bugReportsTab = screen.getByText('Bug Reports');
+      expect(bugReportsTab).toHaveClass('active');
+    });
   });
 
   describe('tab click handlers', () => {
@@ -121,6 +148,17 @@ describe('AdminTabs', () => {
       await user.click(screen.getByText('Map Editor'));
 
       expect(mockOnTabChange).toHaveBeenCalledWith('mapEditor');
+    });
+
+    it('should call onTabChange with bugReports when Bug Reports tab is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <AdminTabs activeTab="review" onTabChange={mockOnTabChange} onBack={mockOnBack} />
+      );
+
+      await user.click(screen.getByText('Bug Reports'));
+
+      expect(mockOnTabChange).toHaveBeenCalledWith('bugReports');
     });
   });
 
@@ -171,7 +209,7 @@ describe('AdminTabs', () => {
         <AdminTabs activeTab="review" onTabChange={mockOnTabChange} onBack={mockOnBack} />
       );
       const tabs = document.querySelectorAll('.admin-tab');
-      expect(tabs.length).toBe(4);
+      expect(tabs.length).toBe(5);
     });
 
     it('should have back-button class', () => {

--- a/react-vite-app/src/components/SubmissionApp/BugReportDetailModal.css
+++ b/react-vite-app/src/components/SubmissionApp/BugReportDetailModal.css
@@ -1,0 +1,551 @@
+/* ===== Bug Report Detail Modal - Dark Glass Theme ===== */
+
+/* Overlay */
+.bug-detail-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  animation: bugDetailOverlayIn 0.2s ease-out;
+}
+
+@keyframes bugDetailOverlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Content card */
+.bug-detail-content {
+  background: linear-gradient(145deg, #1e1e3a 0%, #161630 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  max-width: 640px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 32px;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5), 0 0 40px rgba(139, 92, 246, 0.08);
+  animation: bugDetailSlideIn 0.3s ease-out;
+}
+
+@keyframes bugDetailSlideIn {
+  from { opacity: 0; transform: translateY(20px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Scrollbar */
+.bug-detail-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.bug-detail-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bug-detail-content::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+/* Close button */
+.bug-detail-close {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #8892a8;
+  line-height: 1;
+  padding: 6px 10px;
+  border-radius: 10px;
+  transition: all 0.2s ease;
+  z-index: 1;
+}
+
+.bug-detail-close:hover {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.15);
+}
+
+/* Header */
+.bug-detail-header {
+  margin-bottom: 20px;
+}
+
+.bug-detail-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #e0e6f0;
+  margin: 0 0 12px 0;
+  padding-right: 40px;
+  line-height: 1.3;
+}
+
+.bug-detail-badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bug-detail-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+/* Status badges */
+.bug-detail-badge.status-open {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-detail-badge.status-in-progress {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-detail-badge.status-resolved {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+}
+
+.bug-detail-badge.status-wont-fix {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+.bug-detail-badge.status-closed {
+  background: rgba(136, 146, 168, 0.12);
+  color: #8892a8;
+}
+
+/* Severity badges */
+.bug-detail-badge.severity-low {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-detail-badge.severity-medium {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-detail-badge.severity-high {
+  background: rgba(251, 146, 60, 0.12);
+  color: #fb923c;
+}
+
+.bug-detail-badge.severity-critical {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+/* Category badge */
+.bug-detail-badge.category {
+  background: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+}
+
+/* ===== Sections ===== */
+.bug-detail-section {
+  margin-bottom: 20px;
+}
+
+.bug-detail-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: #8892a8;
+  margin-bottom: 8px;
+}
+
+.bug-detail-section-text {
+  font-size: 14px;
+  color: #c4c9d6;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Reporter info */
+.bug-detail-reporter {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+}
+
+.bug-detail-reporter-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bug-detail-reporter-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #6b7280;
+}
+
+.bug-detail-reporter-value {
+  font-size: 13px;
+  color: #c4c9d6;
+  font-weight: 500;
+}
+
+/* Screenshot */
+.bug-detail-screenshot {
+  margin-bottom: 20px;
+}
+
+.bug-detail-screenshot img {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: block;
+}
+
+/* Environment info */
+.bug-detail-env {
+  margin-bottom: 20px;
+}
+
+.bug-detail-env-toggle {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 10px 14px;
+  color: #8892a8;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.bug-detail-env-toggle:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #c4c9d6;
+}
+
+.bug-detail-env-arrow {
+  transition: transform 0.2s ease;
+}
+
+.bug-detail-env-arrow.open {
+  transform: rotate(180deg);
+}
+
+.bug-detail-env-details {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  padding: 12px 14px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.bug-detail-env-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bug-detail-env-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.bug-detail-env-key {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6b7280;
+}
+
+.bug-detail-env-value {
+  font-size: 12px;
+  color: #8892a8;
+  word-break: break-all;
+}
+
+/* ===== Admin Actions ===== */
+.bug-detail-actions {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.bug-detail-actions-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #e0e6f0;
+  margin-bottom: 14px;
+}
+
+.bug-detail-status-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.bug-detail-status-select {
+  flex: 1;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  transition: all 0.2s ease;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238892a8' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+
+.bug-detail-status-select:focus {
+  outline: none;
+  border-color: rgba(139, 92, 246, 0.5);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.bug-detail-status-select option {
+  background: #1e1e3a;
+  color: #e0e6f0;
+}
+
+.bug-detail-update-btn {
+  padding: 10px 20px;
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.bug-detail-update-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+
+.bug-detail-update-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Note form */
+.bug-detail-note-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bug-detail-note-textarea {
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  transition: all 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 60px;
+  line-height: 1.5;
+}
+
+.bug-detail-note-textarea:focus {
+  outline: none;
+  border-color: rgba(139, 92, 246, 0.5);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.bug-detail-note-textarea::placeholder {
+  color: #4a5568;
+}
+
+.bug-detail-note-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bug-detail-note-char-count {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.bug-detail-add-note-btn {
+  padding: 8px 18px;
+  background: rgba(52, 211, 153, 0.15);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.bug-detail-add-note-btn:hover:not(:disabled) {
+  background: rgba(52, 211, 153, 0.25);
+}
+
+.bug-detail-add-note-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Action messages */
+.bug-detail-action-error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #f87171;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 13px;
+  margin-bottom: 12px;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+.bug-detail-action-success {
+  background: rgba(52, 211, 153, 0.1);
+  color: #34d399;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+/* ===== Admin Notes History ===== */
+.bug-detail-notes {
+  margin-bottom: 20px;
+}
+
+.bug-detail-notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bug-detail-note-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.bug-detail-note-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.bug-detail-note-card-admin {
+  font-size: 12px;
+  font-weight: 700;
+  color: #a78bfa;
+}
+
+.bug-detail-note-card-date {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.bug-detail-note-card-text {
+  font-size: 13px;
+  color: #c4c9d6;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.bug-detail-notes-empty {
+  font-size: 13px;
+  color: #6b7280;
+  text-align: center;
+  padding: 12px;
+}
+
+/* ===== Divider ===== */
+.bug-detail-divider {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  margin: 20px 0;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 480px) {
+  .bug-detail-content {
+    padding: 22px;
+    margin: 10px;
+    border-radius: 20px;
+  }
+
+  .bug-detail-title {
+    font-size: 17px;
+  }
+
+  .bug-detail-reporter {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .bug-detail-env-details {
+    grid-template-columns: 1fr;
+  }
+
+  .bug-detail-status-row {
+    flex-direction: column;
+  }
+
+  .bug-detail-status-select,
+  .bug-detail-update-btn {
+    width: 100%;
+  }
+}

--- a/react-vite-app/src/components/SubmissionApp/BugReportDetailModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/BugReportDetailModal.jsx
@@ -1,0 +1,308 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  updateBugReportStatus,
+  addAdminNote,
+  VALID_STATUSES
+} from '../../services/bugReportService'
+import './BugReportDetailModal.css'
+
+const CATEGORY_LABELS = {
+  gameplay: 'Gameplay',
+  ui: 'UI / Visual',
+  performance: 'Performance',
+  map: 'Map / Location',
+  multiplayer: 'Multiplayer',
+  other: 'Other'
+}
+
+const SEVERITY_LABELS = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical'
+}
+
+const STATUS_LABELS = {
+  'open': 'Open',
+  'in-progress': 'In Progress',
+  'resolved': 'Resolved',
+  'wont-fix': "Won't Fix",
+  'closed': 'Closed'
+}
+
+/**
+ * Format a Firestore timestamp or ISO string for display.
+ */
+function formatDate(timestamp) {
+  if (!timestamp) return 'N/A'
+  const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+}
+
+/**
+ * Admin detail modal for viewing a full bug report and taking actions.
+ *
+ * @param {{ report: object, onClose: function, adminUid: string, adminUsername: string, onReportUpdated: function }} props
+ */
+function BugReportDetailModal({ report, onClose, adminUid, adminUsername, onReportUpdated }) {
+  const [selectedStatus, setSelectedStatus] = useState(report.status)
+  const [noteText, setNoteText] = useState('')
+  const [updatingStatus, setUpdatingStatus] = useState(false)
+  const [addingNote, setAddingNote] = useState(false)
+  const [actionError, setActionError] = useState(null)
+  const [actionSuccess, setActionSuccess] = useState(null)
+  const [showEnvironment, setShowEnvironment] = useState(false)
+
+  const handleUpdateStatus = async () => {
+    if (selectedStatus === report.status) return
+    setActionError(null)
+    setActionSuccess(null)
+
+    try {
+      setUpdatingStatus(true)
+      await updateBugReportStatus(report.id, selectedStatus, adminUid, adminUsername)
+      setActionSuccess('Status updated successfully.')
+      if (onReportUpdated) onReportUpdated()
+      setTimeout(() => setActionSuccess(null), 3000)
+    } catch (err) {
+      console.error('Failed to update status:', err)
+      setActionError(err.message || 'Failed to update status.')
+    } finally {
+      setUpdatingStatus(false)
+    }
+  }
+
+  const handleAddNote = async () => {
+    if (!noteText.trim()) return
+    setActionError(null)
+    setActionSuccess(null)
+
+    try {
+      setAddingNote(true)
+      await addAdminNote(report.id, adminUid, adminUsername, noteText.trim())
+      setNoteText('')
+      setActionSuccess('Note added successfully.')
+      if (onReportUpdated) onReportUpdated()
+      setTimeout(() => setActionSuccess(null), 3000)
+    } catch (err) {
+      console.error('Failed to add note:', err)
+      setActionError(err.message || 'Failed to add note.')
+    } finally {
+      setAddingNote(false)
+    }
+  }
+
+  const env = report.environment || {}
+
+  return createPortal(
+    <div className="bug-detail-overlay" onClick={onClose}>
+      <div className="bug-detail-content" onClick={e => e.stopPropagation()}>
+        <button className="bug-detail-close" onClick={onClose}>&times;</button>
+
+        {/* Header */}
+        <div className="bug-detail-header">
+          <h3 className="bug-detail-title">{report.title}</h3>
+          <div className="bug-detail-badges">
+            <span className={`bug-detail-badge status-${report.status}`}>
+              {STATUS_LABELS[report.status] || report.status}
+            </span>
+            <span className={`bug-detail-badge severity-${report.severity}`}>
+              {SEVERITY_LABELS[report.severity] || report.severity}
+            </span>
+            <span className="bug-detail-badge category">
+              {CATEGORY_LABELS[report.category] || report.category}
+            </span>
+          </div>
+        </div>
+
+        {/* Reporter info */}
+        <div className="bug-detail-reporter">
+          <div className="bug-detail-reporter-item">
+            <span className="bug-detail-reporter-label">Reporter</span>
+            <span className="bug-detail-reporter-value">{report.username}</span>
+          </div>
+          <div className="bug-detail-reporter-item">
+            <span className="bug-detail-reporter-label">Email</span>
+            <span className="bug-detail-reporter-value">{report.userEmail || 'N/A'}</span>
+          </div>
+          <div className="bug-detail-reporter-item">
+            <span className="bug-detail-reporter-label">Submitted</span>
+            <span className="bug-detail-reporter-value">{formatDate(report.createdAt)}</span>
+          </div>
+          <div className="bug-detail-reporter-item">
+            <span className="bug-detail-reporter-label">User ID</span>
+            <span className="bug-detail-reporter-value" style={{ fontSize: 11, fontFamily: 'monospace' }}>
+              {report.userId}
+            </span>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className="bug-detail-section">
+          <div className="bug-detail-section-label">Description</div>
+          <div className="bug-detail-section-text">{report.description}</div>
+        </div>
+
+        {/* Steps to Reproduce */}
+        {report.stepsToReproduce && (
+          <div className="bug-detail-section">
+            <div className="bug-detail-section-label">Steps to Reproduce</div>
+            <div className="bug-detail-section-text">{report.stepsToReproduce}</div>
+          </div>
+        )}
+
+        {/* Screenshot */}
+        {report.screenshot && (
+          <div className="bug-detail-screenshot">
+            <div className="bug-detail-section-label">Screenshot</div>
+            <img src={report.screenshot} alt="Bug screenshot" />
+          </div>
+        )}
+
+        {/* Environment */}
+        {report.environment && (
+          <div className="bug-detail-env">
+            <button
+              className="bug-detail-env-toggle"
+              onClick={() => setShowEnvironment(!showEnvironment)}
+            >
+              <span>Environment Details</span>
+              <span className={`bug-detail-env-arrow ${showEnvironment ? 'open' : ''}`}>
+                &#9660;
+              </span>
+            </button>
+            {showEnvironment && (
+              <div className="bug-detail-env-details">
+                <div className="bug-detail-env-item full-width">
+                  <span className="bug-detail-env-key">User Agent</span>
+                  <span className="bug-detail-env-value">{env.userAgent || 'N/A'}</span>
+                </div>
+                <div className="bug-detail-env-item">
+                  <span className="bug-detail-env-key">Platform</span>
+                  <span className="bug-detail-env-value">{env.platform || 'N/A'}</span>
+                </div>
+                <div className="bug-detail-env-item">
+                  <span className="bug-detail-env-key">Language</span>
+                  <span className="bug-detail-env-value">{env.language || 'N/A'}</span>
+                </div>
+                <div className="bug-detail-env-item">
+                  <span className="bug-detail-env-key">Screen</span>
+                  <span className="bug-detail-env-value">
+                    {env.screenWidth || '?'} x {env.screenHeight || '?'}
+                  </span>
+                </div>
+                <div className="bug-detail-env-item">
+                  <span className="bug-detail-env-key">Window</span>
+                  <span className="bug-detail-env-value">
+                    {env.windowWidth || '?'} x {env.windowHeight || '?'}
+                  </span>
+                </div>
+                <div className="bug-detail-env-item full-width">
+                  <span className="bug-detail-env-key">Captured At</span>
+                  <span className="bug-detail-env-value">{env.timestamp || 'N/A'}</span>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <hr className="bug-detail-divider" />
+
+        {/* Admin Actions */}
+        <div className="bug-detail-actions">
+          <div className="bug-detail-actions-title">Admin Actions</div>
+
+          {actionError && <div className="bug-detail-action-error">{actionError}</div>}
+          {actionSuccess && <div className="bug-detail-action-success">{actionSuccess}</div>}
+
+          {/* Status update */}
+          <div className="bug-detail-status-row">
+            <select
+              className="bug-detail-status-select"
+              value={selectedStatus}
+              onChange={(e) => setSelectedStatus(e.target.value)}
+              disabled={updatingStatus}
+            >
+              {VALID_STATUSES.map(status => (
+                <option key={status} value={status}>
+                  {STATUS_LABELS[status] || status}
+                </option>
+              ))}
+            </select>
+            <button
+              className="bug-detail-update-btn"
+              onClick={handleUpdateStatus}
+              disabled={updatingStatus || selectedStatus === report.status}
+            >
+              {updatingStatus ? 'Updating...' : 'Update Status'}
+            </button>
+          </div>
+
+          {/* Add note */}
+          <div className="bug-detail-note-form">
+            <textarea
+              className="bug-detail-note-textarea"
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              placeholder="Add an admin note..."
+              disabled={addingNote}
+              rows={2}
+              maxLength={500}
+            />
+            <div className="bug-detail-note-row">
+              <span className="bug-detail-note-char-count">{noteText.length}/500</span>
+              <button
+                className="bug-detail-add-note-btn"
+                onClick={handleAddNote}
+                disabled={addingNote || !noteText.trim()}
+              >
+                {addingNote ? 'Adding...' : 'Add Note'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Admin Notes History */}
+        {report.adminNotes && report.adminNotes.length > 0 && (
+          <div className="bug-detail-notes">
+            <div className="bug-detail-section-label">
+              Admin Notes ({report.adminNotes.length})
+            </div>
+            <div className="bug-detail-notes-list">
+              {report.adminNotes.map((note, index) => (
+                <div key={index} className="bug-detail-note-card">
+                  <div className="bug-detail-note-card-header">
+                    <span className="bug-detail-note-card-admin">
+                      {note.adminUsername || 'Admin'}
+                    </span>
+                    <span className="bug-detail-note-card-date">
+                      {formatDate(note.createdAt)}
+                    </span>
+                  </div>
+                  <div className="bug-detail-note-card-text">{note.note}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(!report.adminNotes || report.adminNotes.length === 0) && (
+          <div className="bug-detail-notes">
+            <div className="bug-detail-section-label">Admin Notes</div>
+            <div className="bug-detail-notes-empty">No admin notes yet.</div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default BugReportDetailModal

--- a/react-vite-app/src/components/SubmissionApp/BugReportManagement.css
+++ b/react-vite-app/src/components/SubmissionApp/BugReportManagement.css
@@ -1,0 +1,302 @@
+/* ===== Bug Report Management - Admin Tab ===== */
+
+.bug-mgmt {
+  padding: 24px;
+}
+
+/* Header */
+.bug-mgmt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.bug-mgmt-header h3 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #e0e6f0;
+}
+
+.bug-mgmt-count {
+  font-size: 13px;
+  color: #8892a8;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Error */
+.bug-mgmt-error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #f87171;
+  padding: 12px 16px;
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+/* Loading */
+.bug-mgmt-loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: #8892a8;
+  font-size: 14px;
+}
+
+/* Empty state */
+.bug-mgmt-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: #6b7280;
+}
+
+.bug-mgmt-empty-icon {
+  font-size: 40px;
+  display: block;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+
+.bug-mgmt-empty-text {
+  font-size: 14px;
+}
+
+/* ===== Filters ===== */
+.bug-mgmt-filters {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.bug-mgmt-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bug-mgmt-filter-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #6b7280;
+}
+
+.bug-mgmt-filter-select {
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #e0e6f0;
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath fill='%238892a8' d='M5 7L1 3h8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  min-width: 120px;
+}
+
+.bug-mgmt-filter-select:focus {
+  outline: none;
+  border-color: rgba(139, 92, 246, 0.5);
+  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.1);
+}
+
+.bug-mgmt-filter-select option {
+  background: #1e1e3a;
+  color: #e0e6f0;
+}
+
+/* ===== Table ===== */
+.bug-mgmt-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.bug-mgmt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.bug-mgmt-table thead {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.bug-mgmt-table th {
+  text-align: left;
+  padding: 12px 14px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #6b7280;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+}
+
+.bug-mgmt-table td {
+  padding: 12px 14px;
+  color: #c4c9d6;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  vertical-align: middle;
+}
+
+.bug-mgmt-table tbody tr {
+  transition: background 0.15s ease;
+}
+
+.bug-mgmt-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.bug-mgmt-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Title cell */
+.bug-mgmt-title-cell {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  color: #e0e6f0;
+}
+
+/* Reporter cell */
+.bug-mgmt-reporter-cell {
+  white-space: nowrap;
+}
+
+/* Date cell */
+.bug-mgmt-date-cell {
+  white-space: nowrap;
+  font-size: 12px;
+  color: #8892a8;
+}
+
+/* ===== Badges ===== */
+.bug-mgmt-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+}
+
+/* Status badges */
+.bug-mgmt-badge.status-open {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-mgmt-badge.status-in-progress {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-mgmt-badge.status-resolved {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+}
+
+.bug-mgmt-badge.status-wont-fix {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+.bug-mgmt-badge.status-closed {
+  background: rgba(136, 146, 168, 0.12);
+  color: #8892a8;
+}
+
+/* Severity badges */
+.bug-mgmt-badge.severity-low {
+  background: rgba(96, 165, 250, 0.12);
+  color: #60a5fa;
+}
+
+.bug-mgmt-badge.severity-medium {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.bug-mgmt-badge.severity-high {
+  background: rgba(251, 146, 60, 0.12);
+  color: #fb923c;
+}
+
+.bug-mgmt-badge.severity-critical {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+}
+
+/* Category badges */
+.bug-mgmt-badge.category {
+  background: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+}
+
+/* View button */
+.bug-mgmt-view-btn {
+  padding: 6px 14px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #a78bfa;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.bug-mgmt-view-btn:hover {
+  background: rgba(99, 102, 241, 0.2);
+  color: #c4b5fd;
+  transform: translateY(-1px);
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  .bug-mgmt {
+    padding: 16px;
+  }
+
+  .bug-mgmt-filters {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .bug-mgmt-filter-select {
+    width: 100%;
+  }
+
+  .bug-mgmt-table {
+    font-size: 12px;
+  }
+
+  .bug-mgmt-table th,
+  .bug-mgmt-table td {
+    padding: 10px;
+  }
+
+  .bug-mgmt-title-cell {
+    max-width: 150px;
+  }
+}

--- a/react-vite-app/src/components/SubmissionApp/BugReportManagement.jsx
+++ b/react-vite-app/src/components/SubmissionApp/BugReportManagement.jsx
@@ -1,0 +1,294 @@
+import { useState, useEffect } from 'react'
+import { useAuth } from '../../contexts/AuthContext'
+import {
+  subscribeToBugReports,
+  VALID_CATEGORIES,
+  VALID_SEVERITIES,
+  VALID_STATUSES
+} from '../../services/bugReportService'
+import BugReportDetailModal from './BugReportDetailModal'
+import './BugReportManagement.css'
+
+const CATEGORY_LABELS = {
+  gameplay: 'Gameplay',
+  ui: 'UI / Visual',
+  performance: 'Performance',
+  map: 'Map / Location',
+  multiplayer: 'Multiplayer',
+  other: 'Other'
+}
+
+const SEVERITY_LABELS = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical'
+}
+
+const STATUS_LABELS = {
+  'open': 'Open',
+  'in-progress': 'In Progress',
+  'resolved': 'Resolved',
+  'wont-fix': "Won't Fix",
+  'closed': 'Closed'
+}
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 }
+
+/**
+ * Format a Firestore timestamp or ISO string for display.
+ */
+function formatDate(timestamp) {
+  if (!timestamp) return 'N/A'
+  const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+}
+
+/**
+ * Admin bug report management component.
+ * Shows all bug reports with filtering, sorting, and detail view.
+ */
+function BugReportManagement() {
+  const { user, userDoc } = useAuth()
+
+  const [reports, setReports] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // Filters
+  const [filterStatus, setFilterStatus] = useState('all')
+  const [filterCategory, setFilterCategory] = useState('all')
+  const [filterSeverity, setFilterSeverity] = useState('all')
+  const [sortBy, setSortBy] = useState('date') // 'date' | 'severity'
+
+  // Detail modal
+  const [selectedReport, setSelectedReport] = useState(null)
+
+  // Subscribe to bug reports in real-time
+  useEffect(() => {
+    const unsubscribe = subscribeToBugReports((updatedReports) => {
+      setReports(updatedReports)
+      setLoading(false)
+      setError(null)
+    })
+
+    return () => unsubscribe()
+  }, [])
+
+  // Apply filters and sorting
+  const filteredReports = reports
+    .filter(report => {
+      if (filterStatus !== 'all' && report.status !== filterStatus) return false
+      if (filterCategory !== 'all' && report.category !== filterCategory) return false
+      if (filterSeverity !== 'all' && report.severity !== filterSeverity) return false
+      return true
+    })
+    .sort((a, b) => {
+      if (sortBy === 'severity') {
+        const aSev = SEVERITY_ORDER[a.severity] ?? 99
+        const bSev = SEVERITY_ORDER[b.severity] ?? 99
+        if (aSev !== bSev) return aSev - bSev
+      }
+      // Default to date sort (most recent first)
+      const aTime = a.createdAt?.toMillis?.() || a.createdAt?.seconds * 1000 || 0
+      const bTime = b.createdAt?.toMillis?.() || b.createdAt?.seconds * 1000 || 0
+      return bTime - aTime
+    })
+
+  // When the detail modal triggers an update, refresh the selected report
+  const handleReportUpdated = () => {
+    // The real-time subscription will automatically update the reports list.
+    // We need to update the selectedReport to show the latest data.
+    if (selectedReport) {
+      // Find the updated version in the reports list on next render
+      const updated = reports.find(r => r.id === selectedReport.id)
+      if (updated) {
+        setSelectedReport({ ...updated })
+      }
+    }
+  }
+
+  // Count stats
+  const openCount = reports.filter(r => r.status === 'open').length
+  const inProgressCount = reports.filter(r => r.status === 'in-progress').length
+  const criticalCount = reports.filter(r => r.severity === 'critical' && r.status !== 'resolved' && r.status !== 'closed').length
+
+  if (loading) {
+    return (
+      <div className="bug-mgmt">
+        <div className="bug-mgmt-loading">Loading bug reports...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bug-mgmt">
+      <div className="bug-mgmt-header">
+        <h3>
+          Bug Reports
+          {criticalCount > 0 && (
+            <span style={{ fontSize: 12, color: '#f87171', marginLeft: 10, fontWeight: 600 }}>
+              {criticalCount} critical
+            </span>
+          )}
+        </h3>
+        <span className="bug-mgmt-count">
+          {filteredReports.length} report{filteredReports.length !== 1 ? 's' : ''}
+          {filterStatus === 'all' && ` (${openCount} open, ${inProgressCount} in progress)`}
+        </span>
+      </div>
+
+      {error && <div className="bug-mgmt-error">{error}</div>}
+
+      {/* Filters */}
+      <div className="bug-mgmt-filters">
+        <div className="bug-mgmt-filter-group">
+          <span className="bug-mgmt-filter-label">Status</span>
+          <select
+            className="bug-mgmt-filter-select"
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value)}
+          >
+            <option value="all">All Statuses</option>
+            {VALID_STATUSES.map(status => (
+              <option key={status} value={status}>
+                {STATUS_LABELS[status]} ({reports.filter(r => r.status === status).length})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="bug-mgmt-filter-group">
+          <span className="bug-mgmt-filter-label">Category</span>
+          <select
+            className="bug-mgmt-filter-select"
+            value={filterCategory}
+            onChange={(e) => setFilterCategory(e.target.value)}
+          >
+            <option value="all">All Categories</option>
+            {VALID_CATEGORIES.map(cat => (
+              <option key={cat} value={cat}>
+                {CATEGORY_LABELS[cat]} ({reports.filter(r => r.category === cat).length})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="bug-mgmt-filter-group">
+          <span className="bug-mgmt-filter-label">Severity</span>
+          <select
+            className="bug-mgmt-filter-select"
+            value={filterSeverity}
+            onChange={(e) => setFilterSeverity(e.target.value)}
+          >
+            <option value="all">All Severities</option>
+            {VALID_SEVERITIES.map(sev => (
+              <option key={sev} value={sev}>
+                {SEVERITY_LABELS[sev]} ({reports.filter(r => r.severity === sev).length})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="bug-mgmt-filter-group">
+          <span className="bug-mgmt-filter-label">Sort By</span>
+          <select
+            className="bug-mgmt-filter-select"
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+          >
+            <option value="date">Most Recent</option>
+            <option value="severity">Severity (Critical First)</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {filteredReports.length === 0 && !error && (
+        <div className="bug-mgmt-empty">
+          <span className="bug-mgmt-empty-icon">🐛</span>
+          <div className="bug-mgmt-empty-text">
+            {reports.length === 0
+              ? 'No bug reports have been submitted yet.'
+              : 'No bug reports match your filters.'
+            }
+          </div>
+        </div>
+      )}
+
+      {/* Reports table */}
+      {filteredReports.length > 0 && (
+        <div className="bug-mgmt-table-wrapper">
+          <table className="bug-mgmt-table">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Reporter</th>
+                <th>Category</th>
+                <th>Severity</th>
+                <th>Status</th>
+                <th>Date</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredReports.map(report => (
+                <tr key={report.id}>
+                  <td className="bug-mgmt-title-cell" title={report.title}>
+                    {report.title}
+                  </td>
+                  <td className="bug-mgmt-reporter-cell">
+                    {report.username}
+                  </td>
+                  <td>
+                    <span className="bug-mgmt-badge category">
+                      {CATEGORY_LABELS[report.category] || report.category}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`bug-mgmt-badge severity-${report.severity}`}>
+                      {SEVERITY_LABELS[report.severity] || report.severity}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`bug-mgmt-badge status-${report.status}`}>
+                      {STATUS_LABELS[report.status] || report.status}
+                    </span>
+                  </td>
+                  <td className="bug-mgmt-date-cell">
+                    {formatDate(report.createdAt)}
+                  </td>
+                  <td>
+                    <button
+                      className="bug-mgmt-view-btn"
+                      onClick={() => setSelectedReport(report)}
+                    >
+                      View
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Detail modal */}
+      {selectedReport && (
+        <BugReportDetailModal
+          report={selectedReport}
+          onClose={() => setSelectedReport(null)}
+          adminUid={user?.uid}
+          adminUsername={userDoc?.username}
+          onReportUpdated={handleReportUpdated}
+        />
+      )}
+    </div>
+  )
+}
+
+export default BugReportManagement

--- a/react-vite-app/src/components/SubmissionApp/BugReportManagement.test.jsx
+++ b/react-vite-app/src/components/SubmissionApp/BugReportManagement.test.jsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BugReportManagement from './BugReportManagement';
+
+// Mock Firebase
+vi.mock('../../firebase', () => ({
+  db: {},
+  app: {},
+  auth: {}
+}));
+
+// Mock AuthContext
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { uid: 'admin-uid', email: 'admin@example.com' },
+    userDoc: { uid: 'admin-uid', username: 'AdminUser', isAdmin: true },
+    loading: false,
+    isAdmin: true
+  })
+}));
+
+// Mock bugReportService
+const mockUnsubscribe = vi.fn();
+vi.mock('../../services/bugReportService', () => ({
+  subscribeToBugReports: vi.fn((callback) => {
+    // Call with mock data immediately
+    callback([
+      {
+        id: 'report-1',
+        title: 'Map marker offset bug',
+        username: 'Player1',
+        userEmail: 'player1@test.com',
+        userId: 'user-1',
+        category: 'map',
+        severity: 'high',
+        status: 'open',
+        description: 'The map marker is offset.',
+        createdAt: { toDate: () => new Date('2024-06-15'), toMillis: () => 1718409600000 },
+        adminNotes: []
+      },
+      {
+        id: 'report-2',
+        title: 'UI glitch on mobile',
+        username: 'Player2',
+        userEmail: 'player2@test.com',
+        userId: 'user-2',
+        category: 'ui',
+        severity: 'low',
+        status: 'resolved',
+        description: 'Buttons overlap on small screens.',
+        createdAt: { toDate: () => new Date('2024-06-10'), toMillis: () => 1717977600000 },
+        adminNotes: [{ adminUid: 'admin-1', note: 'Fixed in v2' }]
+      },
+      {
+        id: 'report-3',
+        title: 'Critical crash in multiplayer',
+        username: 'Player3',
+        userEmail: 'player3@test.com',
+        userId: 'user-3',
+        category: 'multiplayer',
+        severity: 'critical',
+        status: 'open',
+        description: 'Game crashes when joining a duel.',
+        createdAt: { toDate: () => new Date('2024-06-20'), toMillis: () => 1718841600000 },
+        adminNotes: []
+      }
+    ]);
+    return mockUnsubscribe;
+  }),
+  updateBugReportStatus: vi.fn(),
+  addAdminNote: vi.fn(),
+  VALID_CATEGORIES: ['gameplay', 'ui', 'performance', 'map', 'multiplayer', 'other'],
+  VALID_SEVERITIES: ['low', 'medium', 'high', 'critical'],
+  VALID_STATUSES: ['open', 'in-progress', 'resolved', 'wont-fix', 'closed']
+}));
+
+// Mock BugReportDetailModal
+vi.mock('./BugReportDetailModal', () => ({
+  default: ({ report, onClose }) => (
+    <div data-testid="bug-detail-modal">
+      <span>Detail: {report.title}</span>
+      <button onClick={onClose}>Close Modal</button>
+    </div>
+  )
+}));
+
+describe('BugReportManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render the Bug Reports header', () => {
+      render(<BugReportManagement />);
+
+      expect(screen.getByText('Bug Reports')).toBeInTheDocument();
+    });
+
+    it('should render the report count', () => {
+      render(<BugReportManagement />);
+
+      expect(screen.getByText(/3 reports/)).toBeInTheDocument();
+    });
+
+    it('should show critical count', () => {
+      render(<BugReportManagement />);
+
+      expect(screen.getByText(/1 critical/)).toBeInTheDocument();
+    });
+
+    it('should render filter dropdowns', () => {
+      const { container } = render(<BugReportManagement />);
+
+      // Filter labels are rendered as .bug-mgmt-filter-label spans
+      const filterLabels = container.querySelectorAll('.bug-mgmt-filter-label');
+      expect(filterLabels.length).toBe(4);
+
+      // Filter selects are rendered as .bug-mgmt-filter-select
+      const filterSelects = container.querySelectorAll('.bug-mgmt-filter-select');
+      expect(filterSelects.length).toBe(4);
+    });
+  });
+
+  describe('table', () => {
+    it('should render table headers', () => {
+      const { container } = render(<BugReportManagement />);
+
+      const headers = container.querySelectorAll('.bug-mgmt-table th');
+      expect(headers.length).toBe(7);
+
+      const headerTexts = Array.from(headers).map(h => h.textContent);
+      expect(headerTexts).toContain('Title');
+      expect(headerTexts).toContain('Reporter');
+      expect(headerTexts).toContain('Actions');
+    });
+
+    it('should render report rows', () => {
+      render(<BugReportManagement />);
+
+      expect(screen.getByText('Map marker offset bug')).toBeInTheDocument();
+      expect(screen.getByText('UI glitch on mobile')).toBeInTheDocument();
+      expect(screen.getByText('Critical crash in multiplayer')).toBeInTheDocument();
+    });
+
+    it('should render reporter names', () => {
+      render(<BugReportManagement />);
+
+      expect(screen.getByText('Player1')).toBeInTheDocument();
+      expect(screen.getByText('Player2')).toBeInTheDocument();
+      expect(screen.getByText('Player3')).toBeInTheDocument();
+    });
+
+    it('should render View buttons for each report', () => {
+      render(<BugReportManagement />);
+
+      const viewButtons = screen.getAllByText('View');
+      expect(viewButtons).toHaveLength(3);
+    });
+  });
+
+  describe('filtering', () => {
+    it('should filter by status', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<BugReportManagement />);
+
+      // Find the status filter select (first .bug-mgmt-filter-select)
+      const filterSelects = container.querySelectorAll('.bug-mgmt-filter-select');
+      const statusSelect = filterSelects[0]; // First select is status
+
+      await user.selectOptions(statusSelect, 'resolved');
+
+      // Only resolved report should be visible
+      expect(screen.getByText('UI glitch on mobile')).toBeInTheDocument();
+      expect(screen.queryByText('Map marker offset bug')).not.toBeInTheDocument();
+      expect(screen.queryByText('Critical crash in multiplayer')).not.toBeInTheDocument();
+    });
+
+    it('should filter by severity', async () => {
+      const user = userEvent.setup();
+      const { container } = render(<BugReportManagement />);
+
+      const filterSelects = container.querySelectorAll('.bug-mgmt-filter-select');
+      const severitySelect = filterSelects[2]; // Third select is severity
+
+      await user.selectOptions(severitySelect, 'critical');
+
+      expect(screen.getByText('Critical crash in multiplayer')).toBeInTheDocument();
+      expect(screen.queryByText('Map marker offset bug')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('detail modal', () => {
+    it('should open detail modal when View button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<BugReportManagement />);
+
+      const viewButtons = screen.getAllByText('View');
+      await user.click(viewButtons[0]);
+
+      expect(screen.getByTestId('bug-detail-modal')).toBeInTheDocument();
+    });
+
+    it('should close detail modal when close is triggered', async () => {
+      const user = userEvent.setup();
+      render(<BugReportManagement />);
+
+      const viewButtons = screen.getAllByText('View');
+      await user.click(viewButtons[0]);
+
+      expect(screen.getByTestId('bug-detail-modal')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Close Modal'));
+
+      expect(screen.queryByTestId('bug-detail-modal')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should unsubscribe from real-time updates on unmount', () => {
+      const { unmount } = render(<BugReportManagement />);
+
+      unmount();
+
+      expect(mockUnsubscribe).toHaveBeenCalled();
+    });
+  });
+});

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.css
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.css
@@ -114,6 +114,24 @@
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.4);
 }
 
+.title-bug-report-button {
+  padding: 8px 16px;
+  background: rgba(251, 146, 60, 0.15);
+  border: 1px solid rgba(251, 146, 60, 0.3);
+  color: #fb923c;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.title-bug-report-button:hover {
+  background: rgba(251, 146, 60, 0.25);
+  color: #fdba74;
+  transform: translateY(-1px);
+}
+
 .title-logout-button {
   padding: 8px 16px;
   background: rgba(231, 76, 60, 0.15);
@@ -351,6 +369,7 @@
   .title-profile-button,
   .title-friends-button,
   .submit-photo-button,
+  .title-bug-report-button,
   .title-logout-button {
     font-size: 12px;
     padding: 6px 12px;

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.jsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../../contexts/AuthContext';
 import './TitleScreen.css';
 
-function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, onOpenLeaderboard, isLoading }) {
+function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, onOpenLeaderboard, onOpenBugReport, isLoading }) {
   const { userDoc, logout, levelInfo, levelTitle } = useAuth();
 
   const handleLogout = async () => {
@@ -32,6 +32,9 @@ function TitleScreen({ onPlay, onOpenSubmission, onOpenProfile, onOpenFriends, o
           </button>
           <button className="submit-photo-button" onClick={onOpenSubmission}>
             Submit Photo
+          </button>
+          <button className="title-bug-report-button" onClick={onOpenBugReport}>
+            Report Bug
           </button>
           <button className="title-logout-button" onClick={handleLogout}>
             Log Out

--- a/react-vite-app/src/components/TitleScreen/TitleScreen.test.jsx
+++ b/react-vite-app/src/components/TitleScreen/TitleScreen.test.jsx
@@ -35,6 +35,9 @@ describe('TitleScreen', () => {
     onPlay: vi.fn(),
     onOpenSubmission: vi.fn(),
     onOpenProfile: vi.fn(),
+    onOpenFriends: vi.fn(),
+    onOpenLeaderboard: vi.fn(),
+    onOpenBugReport: vi.fn(),
     isLoading: false
   };
 
@@ -77,6 +80,12 @@ describe('TitleScreen', () => {
       render(<TitleScreen {...defaultProps} />);
 
       expect(screen.getByRole('button', { name: /submit photo/i })).toBeInTheDocument();
+    });
+
+    it('should render the Report Bug button', () => {
+      render(<TitleScreen {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: /report bug/i })).toBeInTheDocument();
     });
   });
 
@@ -133,6 +142,19 @@ describe('TitleScreen', () => {
       await user.click(screen.getByRole('button', { name: /submit photo/i }));
 
       expect(onOpenSubmission).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Report Bug button', () => {
+    it('should call onOpenBugReport when clicked', async () => {
+      const user = userEvent.setup();
+      const onOpenBugReport = vi.fn();
+
+      render(<TitleScreen {...defaultProps} onOpenBugReport={onOpenBugReport} />);
+
+      await user.click(screen.getByRole('button', { name: /report bug/i }));
+
+      expect(onOpenBugReport).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/react-vite-app/src/services/bugReportService.js
+++ b/react-vite-app/src/services/bugReportService.js
@@ -1,0 +1,279 @@
+import {
+  addDoc,
+  updateDoc,
+  getDoc,
+  doc,
+  collection,
+  query,
+  where,
+  orderBy,
+  getDocs,
+  onSnapshot,
+  serverTimestamp
+} from 'firebase/firestore';
+import { db } from '../firebase';
+
+// ────── Constants ──────
+
+const VALID_CATEGORIES = ['gameplay', 'ui', 'performance', 'map', 'multiplayer', 'other'];
+const VALID_SEVERITIES = ['low', 'medium', 'high', 'critical'];
+const VALID_STATUSES = ['open', 'in-progress', 'resolved', 'wont-fix', 'closed'];
+
+const TITLE_MAX_LENGTH = 100;
+const DESCRIPTION_MAX_LENGTH = 2000;
+const STEPS_MAX_LENGTH = 1000;
+const NOTE_MAX_LENGTH = 500;
+const RATE_LIMIT_MS = 60_000; // 1 minute between reports per user
+
+// Client-side rate limiting map
+const _lastSubmitTimes = new Map();
+
+// ────── Helpers ──────
+
+/**
+ * Capture the current browser/device environment info.
+ * @returns {object} Environment data
+ */
+export function captureEnvironment() {
+  return {
+    userAgent: navigator.userAgent,
+    platform: navigator.platform,
+    language: navigator.language,
+    screenWidth: window.screen.width,
+    screenHeight: window.screen.height,
+    windowWidth: window.innerWidth,
+    windowHeight: window.innerHeight,
+    timestamp: new Date().toISOString()
+  };
+}
+
+// ────── Bug Report CRUD ──────
+
+/**
+ * Submit a new bug report.
+ * Validates required fields and enforces rate limiting.
+ *
+ * @param {object} reportData
+ * @param {string} reportData.userId - Firebase Auth UID
+ * @param {string} reportData.username - Display name
+ * @param {string} reportData.userEmail - Email
+ * @param {string} reportData.title - Bug title (max 100 chars)
+ * @param {string} reportData.category - One of VALID_CATEGORIES
+ * @param {string} reportData.severity - One of VALID_SEVERITIES
+ * @param {string} reportData.description - Detailed description (max 2000 chars)
+ * @param {string} [reportData.stepsToReproduce] - Steps to reproduce (max 1000 chars)
+ * @param {string|null} [reportData.screenshot] - Base64 compressed image or null
+ * @param {object} [reportData.environment] - Browser/device info from captureEnvironment()
+ * @returns {Promise<string>} The new document ID
+ */
+export async function submitBugReport(reportData) {
+  const {
+    userId,
+    username,
+    userEmail,
+    title,
+    category,
+    severity,
+    description,
+    stepsToReproduce = '',
+    screenshot = null,
+    environment = null
+  } = reportData;
+
+  // ── Validation ──
+  if (!userId) throw new Error('User ID is required.');
+  if (!username) throw new Error('Username is required.');
+
+  const trimmedTitle = (title || '').trim();
+  if (!trimmedTitle) throw new Error('Title is required.');
+  if (trimmedTitle.length > TITLE_MAX_LENGTH) {
+    throw new Error(`Title must be ${TITLE_MAX_LENGTH} characters or less.`);
+  }
+
+  if (!VALID_CATEGORIES.includes(category)) {
+    throw new Error('Please select a valid category.');
+  }
+
+  if (!VALID_SEVERITIES.includes(severity)) {
+    throw new Error('Please select a valid severity level.');
+  }
+
+  const trimmedDescription = (description || '').trim();
+  if (!trimmedDescription) throw new Error('Description is required.');
+  if (trimmedDescription.length > DESCRIPTION_MAX_LENGTH) {
+    throw new Error(`Description must be ${DESCRIPTION_MAX_LENGTH} characters or less.`);
+  }
+
+  const trimmedSteps = (stepsToReproduce || '').trim();
+  if (trimmedSteps.length > STEPS_MAX_LENGTH) {
+    throw new Error(`Steps to reproduce must be ${STEPS_MAX_LENGTH} characters or less.`);
+  }
+
+  // ── Rate limiting ──
+  const now = Date.now();
+  const lastSubmit = _lastSubmitTimes.get(userId);
+  if (lastSubmit && now - lastSubmit < RATE_LIMIT_MS) {
+    const remaining = Math.ceil((RATE_LIMIT_MS - (now - lastSubmit)) / 1000);
+    throw new Error(`Please wait ${remaining} seconds before submitting another report.`);
+  }
+
+  // ── Create document ──
+  const docRef = await addDoc(collection(db, 'bugReports'), {
+    userId,
+    username,
+    userEmail: userEmail || '',
+    title: trimmedTitle,
+    category,
+    severity,
+    description: trimmedDescription,
+    stepsToReproduce: trimmedSteps || null,
+    screenshot: screenshot || null,
+    environment: environment || captureEnvironment(),
+    status: 'open',
+    adminNotes: [],
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  });
+
+  // Update rate limit tracker
+  _lastSubmitTimes.set(userId, Date.now());
+
+  return docRef.id;
+}
+
+/**
+ * Subscribe to all bug reports in real-time (admin use).
+ * Returns an unsubscribe function.
+ *
+ * @param {function} callback - Called with array of report objects
+ * @returns {function} Unsubscribe function
+ */
+export function subscribeToBugReports(callback) {
+  const reportsRef = collection(db, 'bugReports');
+  const q = query(reportsRef, orderBy('createdAt', 'desc'));
+
+  return onSnapshot(q, (snapshot) => {
+    const reports = snapshot.docs.map(docSnap => ({
+      id: docSnap.id,
+      ...docSnap.data()
+    }));
+    callback(reports);
+  }, () => {
+    // Fallback if composite index not yet created
+    const fallbackQ = query(reportsRef);
+    return onSnapshot(fallbackQ, (snapshot) => {
+      const reports = snapshot.docs.map(docSnap => ({
+        id: docSnap.id,
+        ...docSnap.data()
+      }));
+      // Sort client-side
+      reports.sort((a, b) => {
+        const aTime = a.createdAt?.toMillis?.() || 0;
+        const bTime = b.createdAt?.toMillis?.() || 0;
+        return bTime - aTime;
+      });
+      callback(reports);
+    });
+  });
+}
+
+/**
+ * Get all bug reports submitted by a specific user.
+ *
+ * @param {string} userId - Firebase Auth UID
+ * @returns {Promise<object[]>} Array of report objects
+ */
+export async function getBugReportsByUser(userId) {
+  if (!userId) return [];
+
+  const reportsRef = collection(db, 'bugReports');
+
+  try {
+    const q = query(reportsRef, where('userId', '==', userId), orderBy('createdAt', 'desc'));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map(docSnap => ({
+      id: docSnap.id,
+      ...docSnap.data()
+    }));
+  } catch {
+    // Fallback without ordering (index may not exist)
+    const q = query(reportsRef, where('userId', '==', userId));
+    const snapshot = await getDocs(q);
+    const reports = snapshot.docs.map(docSnap => ({
+      id: docSnap.id,
+      ...docSnap.data()
+    }));
+    reports.sort((a, b) => {
+      const aTime = a.createdAt?.toMillis?.() || 0;
+      const bTime = b.createdAt?.toMillis?.() || 0;
+      return bTime - aTime;
+    });
+    return reports;
+  }
+}
+
+/**
+ * Update the status of a bug report (admin action).
+ *
+ * @param {string} reportId - Document ID
+ * @param {string} newStatus - One of VALID_STATUSES
+ * @param {string} adminUid - Admin's UID
+ * @param {string} adminUsername - Admin's username
+ */
+export async function updateBugReportStatus(reportId, newStatus, adminUid, _adminUsername) {
+  if (!reportId) throw new Error('Report ID is required.');
+  if (!VALID_STATUSES.includes(newStatus)) {
+    throw new Error('Invalid status value.');
+  }
+  if (!adminUid) throw new Error('Admin UID is required.');
+
+  const reportRef = doc(db, 'bugReports', reportId);
+  await updateDoc(reportRef, {
+    status: newStatus,
+    updatedAt: serverTimestamp()
+  });
+}
+
+/**
+ * Add an admin note to a bug report.
+ *
+ * @param {string} reportId - Document ID
+ * @param {string} adminUid - Admin's UID
+ * @param {string} adminUsername - Admin's username
+ * @param {string} noteText - Note content
+ */
+export async function addAdminNote(reportId, adminUid, adminUsername, noteText) {
+  if (!reportId) throw new Error('Report ID is required.');
+  if (!adminUid) throw new Error('Admin UID is required.');
+
+  const trimmedNote = (noteText || '').trim();
+  if (!trimmedNote) throw new Error('Note cannot be empty.');
+  if (trimmedNote.length > NOTE_MAX_LENGTH) {
+    throw new Error(`Note must be ${NOTE_MAX_LENGTH} characters or less.`);
+  }
+
+  // Fetch current notes, append, and update
+  const reportRef = doc(db, 'bugReports', reportId);
+  const reportSnap = await getDoc(reportRef);
+
+  if (!reportSnap.exists()) {
+    throw new Error('Bug report not found.');
+  }
+
+  const currentNotes = reportSnap.data().adminNotes || [];
+  const newNote = {
+    adminUid,
+    adminUsername: adminUsername || 'Admin',
+    note: trimmedNote,
+    createdAt: new Date().toISOString()
+  };
+
+  await updateDoc(reportRef, {
+    adminNotes: [...currentNotes, newNote],
+    updatedAt: serverTimestamp()
+  });
+}
+
+// ────── Exports for constants (useful for components) ──────
+
+export { VALID_CATEGORIES, VALID_SEVERITIES, VALID_STATUSES };

--- a/react-vite-app/src/services/bugReportService.test.js
+++ b/react-vite-app/src/services/bugReportService.test.js
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Firebase before importing the service
+vi.mock('../firebase', () => ({
+  db: {}
+}));
+
+vi.mock('firebase/firestore', () => ({
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  getDoc: vi.fn(),
+  doc: vi.fn(),
+  collection: vi.fn(),
+  query: vi.fn((...args) => args),
+  where: vi.fn((...args) => args),
+  orderBy: vi.fn((...args) => args),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  serverTimestamp: vi.fn(() => ({ _type: 'serverTimestamp' }))
+}));
+
+import { addDoc, getDocs, getDoc, updateDoc, onSnapshot } from 'firebase/firestore';
+import {
+  submitBugReport,
+  getBugReportsByUser,
+  updateBugReportStatus,
+  addAdminNote,
+  subscribeToBugReports,
+  captureEnvironment,
+  VALID_CATEGORIES,
+  VALID_SEVERITIES,
+  VALID_STATUSES
+} from './bugReportService';
+
+describe('bugReportService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('captureEnvironment', () => {
+    it('should return an object with environment properties', () => {
+      const env = captureEnvironment();
+
+      expect(env).toHaveProperty('userAgent');
+      expect(env).toHaveProperty('platform');
+      expect(env).toHaveProperty('language');
+      expect(env).toHaveProperty('screenWidth');
+      expect(env).toHaveProperty('screenHeight');
+      expect(env).toHaveProperty('windowWidth');
+      expect(env).toHaveProperty('windowHeight');
+      expect(env).toHaveProperty('timestamp');
+    });
+
+    it('should return a valid ISO timestamp', () => {
+      const env = captureEnvironment();
+      const date = new Date(env.timestamp);
+
+      expect(date.toString()).not.toBe('Invalid Date');
+    });
+
+    it('should return numeric screen dimensions', () => {
+      const env = captureEnvironment();
+
+      expect(typeof env.screenWidth).toBe('number');
+      expect(typeof env.screenHeight).toBe('number');
+      expect(typeof env.windowWidth).toBe('number');
+      expect(typeof env.windowHeight).toBe('number');
+    });
+  });
+
+  describe('constants', () => {
+    it('should export valid categories', () => {
+      expect(VALID_CATEGORIES).toContain('gameplay');
+      expect(VALID_CATEGORIES).toContain('ui');
+      expect(VALID_CATEGORIES).toContain('performance');
+      expect(VALID_CATEGORIES).toContain('map');
+      expect(VALID_CATEGORIES).toContain('multiplayer');
+      expect(VALID_CATEGORIES).toContain('other');
+    });
+
+    it('should export valid severities', () => {
+      expect(VALID_SEVERITIES).toContain('low');
+      expect(VALID_SEVERITIES).toContain('medium');
+      expect(VALID_SEVERITIES).toContain('high');
+      expect(VALID_SEVERITIES).toContain('critical');
+    });
+
+    it('should export valid statuses', () => {
+      expect(VALID_STATUSES).toContain('open');
+      expect(VALID_STATUSES).toContain('in-progress');
+      expect(VALID_STATUSES).toContain('resolved');
+      expect(VALID_STATUSES).toContain('wont-fix');
+      expect(VALID_STATUSES).toContain('closed');
+    });
+  });
+
+  describe('submitBugReport', () => {
+    const validReport = {
+      userId: 'user-123',
+      username: 'TestUser',
+      userEmail: 'test@example.com',
+      title: 'Test Bug',
+      category: 'gameplay',
+      severity: 'medium',
+      description: 'This is a test bug description.',
+      stepsToReproduce: '1. Do this\n2. Do that',
+      screenshot: null,
+      environment: { userAgent: 'test', platform: 'test', language: 'en', screenWidth: 1920, screenHeight: 1080, windowWidth: 1920, windowHeight: 1080, timestamp: new Date().toISOString() }
+    };
+
+    it('should submit a valid bug report', async () => {
+      addDoc.mockResolvedValueOnce({ id: 'new-report-id' });
+
+      const id = await submitBugReport(validReport);
+
+      expect(id).toBe('new-report-id');
+      expect(addDoc).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw if title is empty', async () => {
+      await expect(
+        submitBugReport({ ...validReport, title: '' })
+      ).rejects.toThrow('Title is required.');
+    });
+
+    it('should throw if title is whitespace only', async () => {
+      await expect(
+        submitBugReport({ ...validReport, title: '   ' })
+      ).rejects.toThrow('Title is required.');
+    });
+
+    it('should throw if title exceeds 100 characters', async () => {
+      await expect(
+        submitBugReport({ ...validReport, title: 'a'.repeat(101) })
+      ).rejects.toThrow('100 characters or less');
+    });
+
+    it('should throw if userId is missing', async () => {
+      await expect(
+        submitBugReport({ ...validReport, userId: '' })
+      ).rejects.toThrow('User ID is required.');
+    });
+
+    it('should throw if username is missing', async () => {
+      await expect(
+        submitBugReport({ ...validReport, username: '' })
+      ).rejects.toThrow('Username is required.');
+    });
+
+    it('should throw for invalid category', async () => {
+      await expect(
+        submitBugReport({ ...validReport, category: 'invalid' })
+      ).rejects.toThrow('valid category');
+    });
+
+    it('should throw for invalid severity', async () => {
+      await expect(
+        submitBugReport({ ...validReport, severity: 'extreme' })
+      ).rejects.toThrow('valid severity');
+    });
+
+    it('should throw if description is empty', async () => {
+      await expect(
+        submitBugReport({ ...validReport, description: '' })
+      ).rejects.toThrow('Description is required.');
+    });
+
+    it('should throw if description exceeds 2000 characters', async () => {
+      await expect(
+        submitBugReport({ ...validReport, description: 'a'.repeat(2001) })
+      ).rejects.toThrow('2000 characters or less');
+    });
+
+    it('should throw if steps to reproduce exceed 1000 characters', async () => {
+      await expect(
+        submitBugReport({ ...validReport, stepsToReproduce: 'a'.repeat(1001) })
+      ).rejects.toThrow('1000 characters or less');
+    });
+
+    it('should enforce rate limiting for the same user', async () => {
+      addDoc.mockResolvedValue({ id: 'report-1' });
+
+      // First submission should work
+      await submitBugReport({ ...validReport, userId: 'rate-limit-user' });
+
+      // Second immediate submission should be rejected
+      await expect(
+        submitBugReport({ ...validReport, userId: 'rate-limit-user' })
+      ).rejects.toThrow('Please wait');
+    });
+
+    it('should allow submissions from different users', async () => {
+      addDoc.mockResolvedValue({ id: 'report-x' });
+
+      await submitBugReport({ ...validReport, userId: 'userA' });
+      const id = await submitBugReport({ ...validReport, userId: 'userB' });
+
+      expect(id).toBe('report-x');
+    });
+  });
+
+  describe('getBugReportsByUser', () => {
+    it('should return empty array if userId is falsy', async () => {
+      const result = await getBugReportsByUser('');
+      expect(result).toEqual([]);
+    });
+
+    it('should return reports for a user', async () => {
+      const mockDocs = [
+        { id: 'report-1', data: () => ({ title: 'Bug 1', status: 'open', severity: 'low' }) },
+        { id: 'report-2', data: () => ({ title: 'Bug 2', status: 'resolved', severity: 'high' }) }
+      ];
+
+      getDocs.mockResolvedValueOnce({ docs: mockDocs });
+
+      const reports = await getBugReportsByUser('user-123');
+
+      expect(reports).toHaveLength(2);
+      expect(reports[0].id).toBe('report-1');
+      expect(reports[0].title).toBe('Bug 1');
+      expect(reports[1].id).toBe('report-2');
+    });
+  });
+
+  describe('updateBugReportStatus', () => {
+    it('should throw if reportId is missing', async () => {
+      await expect(
+        updateBugReportStatus('', 'resolved', 'admin-1', 'Admin')
+      ).rejects.toThrow('Report ID is required.');
+    });
+
+    it('should throw for invalid status', async () => {
+      await expect(
+        updateBugReportStatus('report-1', 'invalid-status', 'admin-1', 'Admin')
+      ).rejects.toThrow('Invalid status value.');
+    });
+
+    it('should throw if adminUid is missing', async () => {
+      await expect(
+        updateBugReportStatus('report-1', 'resolved', '', 'Admin')
+      ).rejects.toThrow('Admin UID is required.');
+    });
+
+    it('should update the report status', async () => {
+      updateDoc.mockResolvedValueOnce();
+
+      await updateBugReportStatus('report-1', 'resolved', 'admin-1', 'Admin');
+
+      expect(updateDoc).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('addAdminNote', () => {
+    it('should throw if reportId is missing', async () => {
+      await expect(
+        addAdminNote('', 'admin-1', 'Admin', 'A note')
+      ).rejects.toThrow('Report ID is required.');
+    });
+
+    it('should throw if adminUid is missing', async () => {
+      await expect(
+        addAdminNote('report-1', '', 'Admin', 'A note')
+      ).rejects.toThrow('Admin UID is required.');
+    });
+
+    it('should throw if note is empty', async () => {
+      await expect(
+        addAdminNote('report-1', 'admin-1', 'Admin', '')
+      ).rejects.toThrow('Note cannot be empty.');
+    });
+
+    it('should throw if note exceeds 500 characters', async () => {
+      await expect(
+        addAdminNote('report-1', 'admin-1', 'Admin', 'a'.repeat(501))
+      ).rejects.toThrow('500 characters or less');
+    });
+
+    it('should throw if report is not found', async () => {
+      getDoc.mockResolvedValueOnce({ exists: () => false });
+
+      await expect(
+        addAdminNote('report-1', 'admin-1', 'Admin', 'A note')
+      ).rejects.toThrow('Bug report not found.');
+    });
+
+    it('should add a note to an existing report', async () => {
+      getDoc.mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ adminNotes: [] })
+      });
+      updateDoc.mockResolvedValueOnce();
+
+      await addAdminNote('report-1', 'admin-1', 'AdminUser', 'Test note');
+
+      expect(updateDoc).toHaveBeenCalledTimes(1);
+      const updateCall = updateDoc.mock.calls[0][1];
+      expect(updateCall.adminNotes).toHaveLength(1);
+      expect(updateCall.adminNotes[0].adminUid).toBe('admin-1');
+      expect(updateCall.adminNotes[0].adminUsername).toBe('AdminUser');
+      expect(updateCall.adminNotes[0].note).toBe('Test note');
+    });
+
+    it('should append to existing notes', async () => {
+      const existingNotes = [{ adminUid: 'admin-0', adminUsername: 'OldAdmin', note: 'Old note', createdAt: '2024-01-01' }];
+      getDoc.mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ adminNotes: existingNotes })
+      });
+      updateDoc.mockResolvedValueOnce();
+
+      await addAdminNote('report-1', 'admin-1', 'NewAdmin', 'New note');
+
+      const updateCall = updateDoc.mock.calls[0][1];
+      expect(updateCall.adminNotes).toHaveLength(2);
+      expect(updateCall.adminNotes[0].note).toBe('Old note');
+      expect(updateCall.adminNotes[1].note).toBe('New note');
+    });
+  });
+
+  describe('subscribeToBugReports', () => {
+    it('should call onSnapshot and return an unsubscribe function', () => {
+      const mockUnsubscribe = vi.fn();
+      onSnapshot.mockReturnValueOnce(mockUnsubscribe);
+
+      const callback = vi.fn();
+      const unsubscribe = subscribeToBugReports(callback);
+
+      expect(onSnapshot).toHaveBeenCalledTimes(1);
+      expect(typeof unsubscribe).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a full bug reporting system accessible from the main menu "Report Bug" button, with a portal modal for submitting reports (title, category, severity, description, steps to reproduce, screenshot upload) and viewing report history
- Implements a Firestore-backed service layer (`bugReportService.js`) with validation, rate limiting (60s cooldown), environment capture, and admin CRUD operations (status updates, admin notes)
- Adds a "Bug Reports" admin tab with real-time report table, status/category/severity filters, sorting, and a detail modal for managing individual reports

## Test plan
- [x] All 826 tests pass (27 test files)
- [x] ESLint passes with zero errors/warnings
- [x] Project builds without compile-time errors
- [ ] Verify "Report Bug" button appears on main menu and opens the modal
- [ ] Submit a bug report with all fields filled and confirm it appears in Firestore
- [ ] Verify rate limiting prevents rapid re-submission (60s cooldown)
- [ ] Check "My Reports" tab loads user's previous submissions
- [ ] Verify screenshot upload compresses and attaches image
- [ ] Confirm "Bug Reports" tab appears in admin panel with real-time report updates
- [ ] Test admin status changes and admin note additions from detail modal
- [ ] Verify filter dropdowns (status, category, severity) and sort options work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)