### PR TITLE
Add granular permissions system for admin accounts

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/AccountManagement.css
+++ b/react-vite-app/src/components/SubmissionApp/AccountManagement.css
@@ -322,6 +322,75 @@
   transform: translateY(-1px);
 }
 
+/* ===== Permissions Column ===== */
+.permissions-cell {
+  white-space: nowrap;
+}
+
+.permissions-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.permissions-count {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.permissions-count.all-perms {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+.permissions-count.some-perms {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.2);
+}
+
+.permissions-count.no-perms {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+.permissions-edit-button {
+  padding: 4px 12px;
+  background: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+  border: 1px solid rgba(139, 92, 246, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  letter-spacing: 0.3px;
+}
+
+.permissions-edit-button:hover {
+  background: rgba(139, 92, 246, 0.22);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.15);
+  transform: translateY(-1px);
+}
+
+.permissions-locked {
+  font-size: 11px;
+  font-weight: 700;
+  color: #a78bfa;
+  font-style: italic;
+}
+
+.permissions-na {
+  color: #6b7280;
+  font-size: 13px;
+}
+
 .account-management .loading {
   text-align: center;
   padding: 60px;

--- a/react-vite-app/src/components/SubmissionApp/AdminTabs.jsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminTabs.jsx
@@ -1,4 +1,6 @@
 import './AdminTabs.css'
+import { useAuth } from '../../contexts/AuthContext'
+import { ADMIN_PERMISSIONS } from '../../services/userService'
 import AdminReview from './AdminReview'
 import MapEditor from './MapEditor'
 import AccountManagement from './AccountManagement'
@@ -6,6 +8,45 @@ import FriendsManagement from './FriendsManagement'
 import BugReportManagement from './BugReportManagement'
 
 function AdminTabs({ activeTab, onTabChange, onBack }) {
+  const { hasPermission } = useAuth()
+
+  // Define which permissions gate each tab
+  const tabs = [
+    {
+      key: 'review',
+      label: 'Review Submissions',
+      // Visible if user can review submissions OR delete photos
+      visible: hasPermission(ADMIN_PERMISSIONS.REVIEW_SUBMISSIONS) || hasPermission(ADMIN_PERMISSIONS.DELETE_PHOTOS),
+    },
+    {
+      key: 'mapEditor',
+      label: 'Map Editor',
+      visible: hasPermission(ADMIN_PERMISSIONS.EDIT_MAP),
+    },
+    {
+      key: 'accounts',
+      label: 'Manage Accounts',
+      // Visible if user can view, edit, message accounts, or manage admins
+      visible:
+        hasPermission(ADMIN_PERMISSIONS.VIEW_ACCOUNTS) ||
+        hasPermission(ADMIN_PERMISSIONS.EDIT_ACCOUNTS) ||
+        hasPermission(ADMIN_PERMISSIONS.MESSAGE_ACCOUNTS) ||
+        hasPermission(ADMIN_PERMISSIONS.MANAGE_ADMINS),
+    },
+    {
+      key: 'friends',
+      label: 'Friends & Chat',
+      visible: hasPermission(ADMIN_PERMISSIONS.MANAGE_FRIENDS_CHATS),
+    },
+    {
+      key: 'bugReports',
+      label: 'Bug Reports',
+      visible: hasPermission(ADMIN_PERMISSIONS.MANAGE_BUG_REPORTS),
+    },
+  ]
+
+  const visibleTabs = tabs.filter(t => t.visible)
+
   return (
     <div className="admin-panel">
       <div className="admin-panel-header">
@@ -16,44 +57,23 @@ function AdminTabs({ activeTab, onTabChange, onBack }) {
       </div>
 
       <div className="admin-tabs">
-        <button
-          className={`admin-tab ${activeTab === 'review' ? 'active' : ''}`}
-          onClick={() => onTabChange('review')}
-        >
-          Review Submissions
-        </button>
-        <button
-          className={`admin-tab ${activeTab === 'mapEditor' ? 'active' : ''}`}
-          onClick={() => onTabChange('mapEditor')}
-        >
-          Map Editor
-        </button>
-        <button
-          className={`admin-tab ${activeTab === 'accounts' ? 'active' : ''}`}
-          onClick={() => onTabChange('accounts')}
-        >
-          Manage Accounts
-        </button>
-        <button
-          className={`admin-tab ${activeTab === 'friends' ? 'active' : ''}`}
-          onClick={() => onTabChange('friends')}
-        >
-          Friends &amp; Chat
-        </button>
-        <button
-          className={`admin-tab ${activeTab === 'bugReports' ? 'active' : ''}`}
-          onClick={() => onTabChange('bugReports')}
-        >
-          Bug Reports
-        </button>
+        {visibleTabs.map(tab => (
+          <button
+            key={tab.key}
+            className={`admin-tab ${activeTab === tab.key ? 'active' : ''}`}
+            onClick={() => onTabChange(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
       <div className="admin-content">
-        {activeTab === 'review' && <AdminReview />}
-        {activeTab === 'mapEditor' && <MapEditor />}
-        {activeTab === 'accounts' && <AccountManagement />}
-        {activeTab === 'friends' && <FriendsManagement />}
-        {activeTab === 'bugReports' && <BugReportManagement />}
+        {activeTab === 'review' && (hasPermission(ADMIN_PERMISSIONS.REVIEW_SUBMISSIONS) || hasPermission(ADMIN_PERMISSIONS.DELETE_PHOTOS)) && <AdminReview />}
+        {activeTab === 'mapEditor' && hasPermission(ADMIN_PERMISSIONS.EDIT_MAP) && <MapEditor />}
+        {activeTab === 'accounts' && (hasPermission(ADMIN_PERMISSIONS.VIEW_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.EDIT_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.MESSAGE_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.MANAGE_ADMINS)) && <AccountManagement />}
+        {activeTab === 'friends' && hasPermission(ADMIN_PERMISSIONS.MANAGE_FRIENDS_CHATS) && <FriendsManagement />}
+        {activeTab === 'bugReports' && hasPermission(ADMIN_PERMISSIONS.MANAGE_BUG_REPORTS) && <BugReportManagement />}
       </div>
     </div>
   )

--- a/react-vite-app/src/components/SubmissionApp/PermissionsModal.css
+++ b/react-vite-app/src/components/SubmissionApp/PermissionsModal.css
@@ -1,0 +1,277 @@
+/* ===== Permissions Modal - Modern Dark Glass Theme ===== */
+
+/* Overlay */
+.perms-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  animation: permsOverlayIn 0.2s ease-out;
+}
+
+@keyframes permsOverlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Content card */
+.perms-modal-content {
+  background: linear-gradient(145deg, #1e1e3a 0%, #161630 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  max-width: 480px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  padding: 32px;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5), 0 0 40px rgba(139, 92, 246, 0.08);
+  animation: permsSlideIn 0.3s ease-out;
+}
+
+@keyframes permsSlideIn {
+  from { opacity: 0; transform: translateY(20px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Custom scrollbar */
+.perms-modal-content::-webkit-scrollbar {
+  width: 6px;
+}
+.perms-modal-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+.perms-modal-content::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+/* Close button */
+.perms-modal-close {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  font-size: 22px;
+  cursor: pointer;
+  color: #8892a8;
+  line-height: 1;
+  padding: 6px 10px;
+  border-radius: 10px;
+  transition: all 0.2s ease;
+}
+
+.perms-modal-close:hover {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.15);
+}
+
+/* Title */
+.perms-modal-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #e0e6f0;
+  margin: 0 0 6px 0;
+}
+
+/* Subtitle */
+.perms-modal-subtitle {
+  font-size: 14px;
+  color: #8892a8;
+  margin: 0 0 20px 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.perms-modal-count {
+  background: rgba(139, 92, 246, 0.12);
+  color: #a78bfa;
+  padding: 3px 10px;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  border: 1px solid rgba(139, 92, 246, 0.2);
+}
+
+/* Error */
+.perms-modal-error {
+  background: rgba(248, 113, 113, 0.1);
+  color: #f87171;
+  padding: 12px 16px;
+  border-radius: 12px;
+  margin-bottom: 18px;
+  font-size: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+/* Form */
+.perms-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Quick action buttons */
+.perms-modal-quick-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.perms-quick-btn {
+  padding: 7px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  letter-spacing: 0.3px;
+  border: none;
+}
+
+.perms-quick-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.perms-select-all {
+  background: rgba(52, 211, 153, 0.12);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+.perms-select-all:hover:not(:disabled) {
+  background: rgba(52, 211, 153, 0.22);
+}
+
+.perms-select-none {
+  background: rgba(255, 255, 255, 0.06);
+  color: #8892a8;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.perms-select-none:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #c4c9d6;
+}
+
+/* Permissions list */
+.perms-modal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 12px;
+}
+
+.perms-modal-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.perms-modal-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.perms-modal-item input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #8b5cf6;
+  flex-shrink: 0;
+}
+
+.perms-modal-item-label {
+  font-size: 14px;
+  color: #c4c9d6;
+  font-weight: 500;
+}
+
+/* Action buttons */
+.perms-modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.perms-modal-save {
+  flex: 1;
+  padding: 13px;
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
+}
+
+.perms-modal-save:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.4);
+}
+
+.perms-modal-save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.perms-modal-cancel {
+  flex: 1;
+  padding: 13px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #b0b8cc;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.perms-modal-cancel:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.perms-modal-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 480px) {
+  .perms-modal-content {
+    padding: 22px;
+    margin: 10px;
+    border-radius: 20px;
+  }
+
+  .perms-modal-quick-actions {
+    flex-direction: column;
+  }
+
+  .perms-modal-actions {
+    flex-direction: column;
+  }
+}

--- a/react-vite-app/src/components/SubmissionApp/PermissionsModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/PermissionsModal.jsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ADMIN_PERMISSIONS, PERMISSION_LABELS, getAllPermissions, getNoPermissions } from '../../services/userService'
+import './PermissionsModal.css'
+
+/**
+ * Modal for editing an admin user's granular permissions.
+ * Displays a checkbox for each permission defined in ADMIN_PERMISSIONS.
+ *
+ * @param {{ user: object, onSave: function, onClose: function, isSaving: boolean }} props
+ */
+function PermissionsModal({ user, onSave, onClose, isSaving }) {
+  const allPermKeys = Object.values(ADMIN_PERMISSIONS)
+  const currentPerms = user.permissions || {}
+
+  const [permissions, setPermissions] = useState(
+    Object.fromEntries(
+      allPermKeys.map(key => [key, !!currentPerms[key]])
+    )
+  )
+  const [error, setError] = useState(null)
+
+  const handleToggle = (permKey) => {
+    setPermissions(prev => ({ ...prev, [permKey]: !prev[permKey] }))
+    setError(null)
+  }
+
+  const handleSelectAll = () => {
+    setPermissions(getAllPermissions())
+    setError(null)
+  }
+
+  const handleSelectNone = () => {
+    setPermissions(getNoPermissions())
+    setError(null)
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    try {
+      await onSave(user.id, permissions)
+    } catch (err) {
+      setError(err.message || 'Failed to update permissions.')
+    }
+  }
+
+  const grantedCount = Object.values(permissions).filter(Boolean).length
+  const totalCount = allPermKeys.length
+
+  return createPortal(
+    <div className="perms-modal-overlay" onClick={onClose}>
+      <div className="perms-modal-content" onClick={e => e.stopPropagation()}>
+        <button className="perms-modal-close" onClick={onClose}>&times;</button>
+
+        <h3 className="perms-modal-title">
+          Edit Permissions
+        </h3>
+        <p className="perms-modal-subtitle">
+          {user.username || user.id}
+          <span className="perms-modal-count">{grantedCount}/{totalCount} granted</span>
+        </p>
+
+        {error && <div className="perms-modal-error">{error}</div>}
+
+        <form onSubmit={handleSubmit} className="perms-modal-form">
+          <div className="perms-modal-quick-actions">
+            <button type="button" className="perms-quick-btn perms-select-all" onClick={handleSelectAll} disabled={isSaving}>
+              Select All
+            </button>
+            <button type="button" className="perms-quick-btn perms-select-none" onClick={handleSelectNone} disabled={isSaving}>
+              Select None
+            </button>
+          </div>
+
+          <div className="perms-modal-list">
+            {allPermKeys.map(permKey => (
+              <label key={permKey} className="perms-modal-item">
+                <input
+                  type="checkbox"
+                  checked={permissions[permKey]}
+                  onChange={() => handleToggle(permKey)}
+                  disabled={isSaving}
+                />
+                <span className="perms-modal-item-label">{PERMISSION_LABELS[permKey]}</span>
+              </label>
+            ))}
+          </div>
+
+          <div className="perms-modal-actions">
+            <button
+              type="submit"
+              className="perms-modal-save"
+              disabled={isSaving}
+            >
+              {isSaving ? 'Saving...' : 'Save Permissions'}
+            </button>
+            <button
+              type="button"
+              className="perms-modal-cancel"
+              onClick={onClose}
+              disabled={isSaving}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default PermissionsModal

--- a/react-vite-app/src/components/SubmissionApp/SubmissionApp.jsx
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionApp.jsx
@@ -1,15 +1,26 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useAuth } from '../../contexts/AuthContext'
+import { ADMIN_PERMISSIONS } from '../../services/userService'
 import SubmissionForm from './SubmissionForm'
 import AdminTabs from './AdminTabs'
 import './SubmissionApp.css'
 
 function SubmissionApp({ onBack }) {
-  const { isAdmin } = useAuth()
+  const { isAdmin, hasPermission } = useAuth()
   const [adminScreen, setAdminScreen] = useState(null) // null | 'review' | 'mapEditor' | 'accounts'
 
+  // Determine the first visible tab to land on when entering admin panel
+  const firstVisibleTab = useMemo(() => {
+    if (hasPermission(ADMIN_PERMISSIONS.REVIEW_SUBMISSIONS) || hasPermission(ADMIN_PERMISSIONS.DELETE_PHOTOS)) return 'review'
+    if (hasPermission(ADMIN_PERMISSIONS.EDIT_MAP)) return 'mapEditor'
+    if (hasPermission(ADMIN_PERMISSIONS.VIEW_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.EDIT_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.MESSAGE_ACCOUNTS) || hasPermission(ADMIN_PERMISSIONS.MANAGE_ADMINS)) return 'accounts'
+    if (hasPermission(ADMIN_PERMISSIONS.MANAGE_FRIENDS_CHATS)) return 'friends'
+    if (hasPermission(ADMIN_PERMISSIONS.MANAGE_BUG_REPORTS)) return 'bugReports'
+    return 'review' // fallback
+  }, [hasPermission])
+
   const handleAdminClick = () => {
-    setAdminScreen('review')
+    setAdminScreen(firstVisibleTab)
   }
 
   const handleBackToSubmission = () => {

--- a/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
+++ b/react-vite-app/src/components/SubmissionApp/UserEditModal.jsx
@@ -6,7 +6,7 @@ import './UserEditModal.css'
 
 function UserEditModal({ user, onSave, onClose, isSaving }) {
   // Known fields we render explicitly with nice UI
-  const knownFields = ['uid', 'id', 'email', 'username', 'isAdmin', 'emailVerified', 'verified', 'createdAt', 'totalXp', 'gamesPlayed', 'lastGameAt']
+  const knownFields = ['uid', 'id', 'email', 'username', 'isAdmin', 'emailVerified', 'verified', 'createdAt', 'totalXp', 'gamesPlayed', 'lastGameAt', 'permissions']
 
   // Extra/dynamic fields beyond the known set
   const extraFields = Object.keys(user).filter(


### PR DESCRIPTION
## Summary
- Adds 9 granular permissions to each admin account: review submissions, delete photos, edit map, view accounts, edit accounts, message accounts, manage admins & permissions, manage friends & chats, and manage bug reports
- Admin tabs and action buttons are now gated by the current user's specific permissions — admins only see tabs/actions they have access to
- The hardcoded admin is always granted all permissions (cannot be modified)
- New `PermissionsModal` component allows admins with the "Manage Admins" permission to edit another admin's individual permissions via a checkbox UI
- When granting admin status, all permissions are enabled by default; when revoking, all are cleared
- Permissions are stored as a `permissions` map in the user's Firestore document and exposed via `AuthContext` (`permissions`, `hasPermission()`)

## Test plan
- [ ] Verify the hardcoded admin sees all 9 permissions as granted and all tabs are visible
- [ ] Grant admin to a regular user and confirm they receive all permissions by default
- [ ] Edit a non-hardcoded admin's permissions (e.g. remove "Edit Map") and confirm the Map Editor tab disappears for that user
- [ ] Revoke admin from a user and confirm all permissions are cleared
- [ ] Confirm the "Edit" button on permissions column does not appear for the hardcoded admin row
- [ ] Confirm action buttons (Edit, Message, Make Admin) only appear for admins with the corresponding permission
- [ ] Verify build succeeds with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)