### PR TITLE
Add "Friends" visibility option for game lobbies

### DIFF
--- a/react-vite-app/src/components/MultiplayerLobby/MultiplayerLobby.jsx
+++ b/react-vite-app/src/components/MultiplayerLobby/MultiplayerLobby.jsx
@@ -15,6 +15,7 @@ function MultiplayerLobby({ difficulty, userUid, userUsername, onJoinedLobby, on
   const [visibility, setVisibility] = useState('public');
   const {
     publicLobbies,
+    friendsLobbies,
     isCreating,
     isJoining,
     error,
@@ -86,6 +87,13 @@ function MultiplayerLobby({ difficulty, userUid, userUsername, onJoinedLobby, on
                 Public
               </button>
               <button
+                className={`lobby-vis-btn ${visibility === 'friends' ? 'selected' : ''}`}
+                onClick={() => setVisibility('friends')}
+              >
+                <span className="lobby-vis-icon">👥</span>
+                Friends
+              </button>
+              <button
                 className={`lobby-vis-btn ${visibility === 'private' ? 'selected' : ''}`}
                 onClick={() => setVisibility('private')}
               >
@@ -129,6 +137,20 @@ function MultiplayerLobby({ difficulty, userUid, userUsername, onJoinedLobby, on
           </p>
           <PublicGameList
             lobbies={publicLobbies}
+            selectedDifficulty={difficulty}
+            onJoin={handleJoinPublic}
+            isJoining={isJoining}
+          />
+        </div>
+
+        {/* Browse Friends' Games */}
+        <div className="lobby-public-section">
+          <h2 className="lobby-section-heading">Friends' Games</h2>
+          <p className="lobby-section-desc">
+            Games hosted by your friends — only {diffInfo.label} difficulty games can be joined
+          </p>
+          <PublicGameList
+            lobbies={friendsLobbies}
             selectedDifficulty={difficulty}
             onJoin={handleJoinPublic}
             isJoining={isJoining}

--- a/react-vite-app/src/components/WaitingRoom/WaitingRoom.css
+++ b/react-vite-app/src/components/WaitingRoom/WaitingRoom.css
@@ -220,6 +220,11 @@
   color: #3498db;
 }
 
+.waiting-badge-vis.friends {
+  border-color: rgba(155, 89, 182, 0.3);
+  color: #9b59b6;
+}
+
 .waiting-badge-vis.private {
   border-color: rgba(243, 156, 18, 0.3);
   color: #f39c12;

--- a/react-vite-app/src/components/WaitingRoom/WaitingRoom.jsx
+++ b/react-vite-app/src/components/WaitingRoom/WaitingRoom.jsx
@@ -127,7 +127,9 @@ function WaitingRoom({ lobbyDocId, userUid, onLeave, onGameStart }) {
             {diffInfo.icon} {diffInfo.label}
           </span>
           <span className={`waiting-badge waiting-badge-vis ${lobby.visibility}`}>
-            {lobby.visibility === 'public' ? '🌐 Public' : '🔒 Private'}
+            {lobby.visibility === 'public' && '🌐 Public'}
+            {lobby.visibility === 'friends' && '👥 Friends'}
+            {lobby.visibility === 'private' && '🔒 Private'}
           </span>
           <span className="waiting-badge waiting-badge-count">
             {playerCount}/{maxPlayers} Players


### PR DESCRIPTION
## Summary
- Adds a **"Friends"** visibility option alongside Public and Private when hosting a game
- Friends-only lobbies are only visible to the host's friends in a new **"Friends' Games"** browse section
- Non-friends are blocked from joining friends-only lobbies, even via game code
- Adds a purple **👥 Friends** badge in the waiting room to distinguish the visibility type

## Test plan
- [ ] Navigate to Multiplayer Lobby and verify three toggle buttons appear: Public, Friends, Private
- [ ] Create a friends-only game and confirm it does NOT appear in the Public Games list
- [ ] Log in as a friend of the host and confirm the game appears under "Friends' Games"
- [ ] Log in as a non-friend and confirm the game does NOT appear in any list
- [ ] Try joining a friends-only game via game code as a non-friend — confirm error message
- [ ] Check the WaitingRoom shows a purple "👥 Friends" badge for friends-only lobbies

🤖 Generated with [Claude Code](https://claude.com/claude-code)