### PR TITLE
Fix missing onSnapshot error handlers in friendService

### DIFF
--- a/react-vite-app/src/services/friendService.js
+++ b/react-vite-app/src/services/friendService.js
@@ -245,6 +245,9 @@ export function subscribeFriendRequests(uid, callback) {
       return bTime - aTime;
     });
     callback(requests);
+  }, (error) => {
+    console.error('Error subscribing to friend requests (non-fatal):', error);
+    callback([]);
   });
 }
 
@@ -267,6 +270,11 @@ export function subscribeFriendsList(uid, callback) {
       };
     });
     callback(friends);
+  }, (error) => {
+    console.error('Error subscribing to friends list (non-fatal):', error);
+    // Return empty list so the UI still works — friends features degrade
+    // gracefully but core multiplayer (host/join) is unaffected.
+    callback([]);
   });
 }
 

--- a/react-vite-app/src/services/friendService.test.js
+++ b/react-vite-app/src/services/friendService.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock Firestore boundary only ────────────────────────────────
+vi.mock('../firebase', () => ({
+  db: { _marker: 'mock-db' }
+}));
+
+let onSnapshotCalls = [];
+const mockUnsub = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db, _col, id) => ({ id, path: `${_col}/${id}` })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  getDocs: vi.fn(() => ({ empty: true, docs: [] })),
+  collection: vi.fn((_db, name) => ({ _collectionName: name })),
+  query: vi.fn((...args) => ({ _queryArgs: args })),
+  where: vi.fn((field, op, val) => ({ _type: 'where', field, op, val })),
+  orderBy: vi.fn((...args) => ({ _type: 'orderBy', args })),
+  onSnapshot: vi.fn((q, successCb, errorCb) => {
+    onSnapshotCalls.push({ query: q, successCb, errorCb });
+    return mockUnsub;
+  }),
+  arrayUnion: vi.fn(val => val),
+  arrayRemove: vi.fn(val => val),
+  serverTimestamp: vi.fn(() => ({ _type: 'serverTimestamp' }))
+}));
+
+import { onSnapshot } from 'firebase/firestore';
+import { subscribeFriendsList, subscribeFriendRequests } from './friendService';
+
+describe('friendService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSnapshotCalls = [];
+  });
+
+  describe('subscribeFriendsList', () => {
+    it('should call onSnapshot with an error callback', () => {
+      const callback = vi.fn();
+      subscribeFriendsList('user-1', callback);
+
+      expect(onSnapshot).toHaveBeenCalledTimes(1);
+      const call = onSnapshotCalls[0];
+
+      // The critical assertion: errorCb must be defined
+      // Without it, Firestore errors become unhandled and crash the app
+      expect(call.errorCb).toBeDefined();
+      expect(typeof call.errorCb).toBe('function');
+    });
+
+    it('should query the friends collection with array-contains', () => {
+      const callback = vi.fn();
+      subscribeFriendsList('user-1', callback);
+
+      const call = onSnapshotCalls[0];
+      const queryArgs = call.query._queryArgs;
+
+      // First arg is the collection ref
+      expect(queryArgs[0]._collectionName).toBe('friends');
+
+      // Second arg is the where clause
+      const whereClause = queryArgs.find(a => a._type === 'where');
+      expect(whereClause).toEqual({
+        _type: 'where',
+        field: 'users',
+        op: 'array-contains',
+        val: 'user-1'
+      });
+    });
+
+    it('should call callback with empty array when onSnapshot error fires', () => {
+      const callback = vi.fn();
+      subscribeFriendsList('user-1', callback);
+
+      const call = onSnapshotCalls[0];
+
+      // Simulate Firestore error
+      call.errorCb(new Error('Permission denied'));
+
+      expect(callback).toHaveBeenCalledWith([]);
+    });
+
+    it('should map snapshot docs correctly on success', () => {
+      const callback = vi.fn();
+      subscribeFriendsList('user-1', callback);
+
+      const call = onSnapshotCalls[0];
+
+      call.successCb({
+        docs: [
+          {
+            id: 'pair-1',
+            data: () => ({
+              users: ['user-1', 'friend-A'],
+              usernames: { 'user-1': 'Me', 'friend-A': 'Alice' },
+              since: 'some-timestamp'
+            })
+          }
+        ]
+      });
+
+      expect(callback).toHaveBeenCalledWith([
+        {
+          pairId: 'pair-1',
+          friendUid: 'friend-A',
+          friendUsername: 'Alice',
+          since: 'some-timestamp'
+        }
+      ]);
+    });
+
+    it('should return the unsubscribe function', () => {
+      const callback = vi.fn();
+      const unsub = subscribeFriendsList('user-1', callback);
+      expect(unsub).toBe(mockUnsub);
+    });
+  });
+
+  describe('subscribeFriendRequests', () => {
+    it('should call onSnapshot with an error callback', () => {
+      const callback = vi.fn();
+      subscribeFriendRequests('user-1', callback);
+
+      expect(onSnapshot).toHaveBeenCalledTimes(1);
+      const call = onSnapshotCalls[0];
+
+      // Must have error handler to prevent unhandled Firestore errors
+      expect(call.errorCb).toBeDefined();
+      expect(typeof call.errorCb).toBe('function');
+    });
+
+    it('should call callback with empty array when onSnapshot error fires', () => {
+      const callback = vi.fn();
+      subscribeFriendRequests('user-1', callback);
+
+      const call = onSnapshotCalls[0];
+      call.errorCb(new Error('Network error'));
+
+      expect(callback).toHaveBeenCalledWith([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: `subscribeFriendsList` and `subscribeFriendRequests` in `friendService.js` called Firestore's `onSnapshot()` with only a success callback — **no error callback**. When Firestore fires an async error (permissions, network, missing index), the error is unhandled and crashes the React app, breaking all multiplayer.
- The previous try/catch fix in `useLobby.js` only catches synchronous throws — `onSnapshot` errors fire asynchronously after the call returns, so the try/catch never sees them.
- Added error callbacks that log and call `callback([])` for graceful degradation
- Added `friendService.test.js` (7 unit tests) verifying error handlers exist and work
- Added resilience test to `useLobby.test.js` for the async error scenario

## Test plan
- [x] 20 useLobby integration tests pass (including 4 resilience tests)
- [x] 7 friendService unit tests pass (verifying error handlers exist)
- [x] 29 lobbyService tests pass
- [x] 7 friendsLobbyService tests pass
- [x] 19 MultiplayerLobby component tests pass
- [x] 14 WaitingRoom component tests pass
- [x] 96 total lobby/friends tests pass
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)