### PR TITLE
Fix Firestore corruption: remove fallback onSnapshot from error callbacks

### DIFF
--- a/react-vite-app/src/services/friendsLobbyService.js
+++ b/react-vite-app/src/services/friendsLobbyService.js
@@ -15,8 +15,6 @@ import { db } from '../firebase';
  * @returns {function} Unsubscribe function
  */
 export function subscribeFriendsLobbies(callback) {
-  let fallbackUnsub = null;
-
   const q = query(
     collection(db, 'lobbies'),
     where('visibility', '==', 'friends'),
@@ -24,41 +22,19 @@ export function subscribeFriendsLobbies(callback) {
     orderBy('createdAt', 'desc')
   );
 
-  const primaryUnsub = onSnapshot(q, (snapshot) => {
+  return onSnapshot(q, (snapshot) => {
     const lobbies = snapshot.docs.map(docSnap => ({
       docId: docSnap.id,
       ...docSnap.data()
     }));
     callback(lobbies);
   }, (error) => {
+    // DO NOT create a fallback onSnapshot here. Starting a new listener
+    // inside an onSnapshot error callback corrupts Firestore's internal
+    // WatchChangeAggregator state, causing INTERNAL ASSERTION FAILED errors
+    // that break ALL subsequent Firestore operations (including writes).
     console.error('Error subscribing to friends lobbies:', error);
-    // Fallback: query without orderBy (in case index is missing)
-    const fallbackQ = query(
-      collection(db, 'lobbies'),
-      where('visibility', '==', 'friends'),
-      where('status', '==', 'waiting')
-    );
-    fallbackUnsub = onSnapshot(fallbackQ, (snapshot) => {
-      const lobbies = snapshot.docs.map(docSnap => ({
-        docId: docSnap.id,
-        ...docSnap.data()
-      }));
-      // Sort client-side as fallback
-      lobbies.sort((a, b) => {
-        const aTime = a.createdAt?.toMillis?.() || 0;
-        const bTime = b.createdAt?.toMillis?.() || 0;
-        return bTime - aTime;
-      });
-      callback(lobbies);
-    }, (fallbackError) => {
-      console.error('Fallback friends lobbies query also failed:', fallbackError);
-      callback([]);
-    });
+    console.error('Create the required composite index at the link above.');
+    callback([]);
   });
-
-  // Return a cleanup function that unsubscribes from both listeners
-  return () => {
-    primaryUnsub();
-    if (fallbackUnsub) fallbackUnsub();
-  };
 }


### PR DESCRIPTION
## Summary
- **Root cause identified**: `subscribePublicLobbies` and `subscribeFriendsLobbies` created fallback `onSnapshot` listeners inside the error callback of the primary `onSnapshot`. This corrupts Firestore's internal `WatchChangeAggregator` state machine, causing `INTERNAL ASSERTION FAILED: Unexpected state` errors that poison ALL subsequent Firestore operations — including `addDoc` (game creation).
- **Fix**: Error callbacks now just log the error and call `callback([])` — no new listeners are created inside error handlers.
- **Tests updated**: Added test that explicitly verifies no nested `onSnapshot` calls are created when primary queries fail. Removed old tests that validated the (broken) fallback behavior.

## What was happening
1. Missing composite index → `onSnapshot` fires error callback
2. Error callback creates a new `onSnapshot` (fallback listener)
3. Firestore's internal state machine corrupts → `INTERNAL ASSERTION FAILED: Unexpected state`
4. ALL subsequent Firestore operations fail, including `addDoc` for creating games
5. Multiplayer is completely broken

## Test plan
- [x] `useLobby.test.js` — "should NOT create fallback onSnapshot listeners when primary queries fail" (was failing before fix, now passes)
- [x] `lobbyService.test.js` — "should call callback with empty array on error (no fallback listener)"
- [x] `friendsLobbyService.test.js` — "should call callback with empty array on error (no fallback listener)"
- [x] `MultiplayerLobby.integration.test.jsx` — end-to-end test verifying game creation works even after all listeners fail
- [x] All 102 lobby-related tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)