### PR TITLE
Reduce region point hover expansion size in map editor

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/PolygonDrawer.css
+++ b/react-vite-app/src/components/SubmissionApp/PolygonDrawer.css
@@ -77,7 +77,7 @@
 }
 
 .polygon-vertex:hover {
-  r: 10;
+  r: 1.5;
   fill: #8b5cf6;
 }
 


### PR DESCRIPTION
## Summary
- Reduced the polygon vertex hover radius from `r: 10` to `r: 1.5` in the map editor
- The previous value caused an oversized circle to appear on hover (10x expansion in a 0-100 viewBox), making it visually distracting when moving region points
- The new value provides a subtle 50% expansion from the base `r=1`, keeping the hover feedback without the large circle

## Test plan
- [ ] Open the map editor and select a region
- [ ] Hover over region vertex points and verify the hover expansion is subtle and not oversized
- [ ] Confirm vertices are still easy to grab and drag for repositioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)