### PR TITLE
Enforces username change limits

### DIFF
--- a/react-vite-app/package-lock.json
+++ b/react-vite-app/package-lock.json
@@ -133,6 +133,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -492,6 +493,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -532,6 +534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1216,6 +1219,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1282,6 +1286,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -1297,7 +1302,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -1748,6 +1754,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2417,8 +2424,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2512,6 +2518,7 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2522,6 +2529,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2571,6 +2579,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2964,6 +2973,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3136,6 +3146,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3384,8 +3395,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -3490,6 +3500,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4131,6 +4142,7 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4287,7 +4299,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4540,6 +4551,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4592,7 +4604,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4608,7 +4619,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4655,6 +4665,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4664,6 +4675,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4676,8 +4688,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -5080,6 +5091,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5151,6 +5163,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5226,6 +5239,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5514,6 +5528,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/react-vite-app/src/components/ProfileScreen/ProfileScreen.css
+++ b/react-vite-app/src/components/ProfileScreen/ProfileScreen.css
@@ -295,6 +295,16 @@
   flex-wrap: wrap;
 }
 
+.profile-username-note {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  width: 100%;
+}
+
 .profile-input {
   flex: 1;
   min-width: 0;

--- a/react-vite-app/src/components/ProfileScreen/ProfileScreen.tsx
+++ b/react-vite-app/src/components/ProfileScreen/ProfileScreen.tsx
@@ -128,6 +128,9 @@ function ProfileScreen({ onBack, onOpenFriends }: ProfileScreenProps): React.Rea
                   autoFocus
                   disabled={isSaving}
                 />
+                <div className="profile-username-note">
+                  Changing your username is allowed once every 30 days.
+                </div>
                 <button
                   className="profile-save-button"
                   onClick={handleSave}

--- a/react-vite-app/src/contexts/AuthContext.tsx
+++ b/react-vite-app/src/contexts/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
   User as FirebaseUser
 } from 'firebase/auth';
 import { auth } from '../firebase';
-import { createUserDoc, getUserDoc, updateUserDoc, isUsernameTaken, isHardcodedAdmin, getAllPermissions, getNoPermissions, ADMIN_PERMISSIONS } from '../services/userService';
+import { createUserDoc, getUserDoc, updateUserDoc, updateUserProfile, isUsernameTaken, isHardcodedAdmin, getAllPermissions, getNoPermissions, ADMIN_PERMISSIONS } from '../services/userService';
 import { getLevelInfo, getLevelTitle } from '../utils/xpLevelling';
 
 /**
@@ -272,14 +272,11 @@ export function AuthProvider({ children }: AuthProviderProps): React.ReactElemen
    */
   const updateUsername = useCallback(async (newUsername: string): Promise<void> => {
     if (!user) throw new Error('No authenticated user');
-
-    const taken = await isUsernameTaken(newUsername, user.uid);
-    if (taken) {
-      throw new Error('Username is already taken. Please choose another.');
-    }
-
-    await updateUserDoc(user.uid, { username: newUsername });
-    setUserDoc(prev => prev ? { ...prev, username: newUsername } : prev);
+    // Enforce server-side rules (uniqueness + 30-day cooldown)
+    await updateUserProfile(user.uid, { username: newUsername });
+    // Refresh local userDoc to pick up serverTimestamp fields like lastUsernameChange
+    const doc = await getUserDoc(user.uid) as UserDoc | null;
+    if (doc) setUserDoc(doc);
   }, [user]);
 
   /**

--- a/react-vite-app/src/services/userService.ts
+++ b/react-vite-app/src/services/userService.ts
@@ -30,6 +30,7 @@ export interface UserDoc {
   createdAt: unknown;
   permissions?: PermissionsMap;
   lastGameAt?: unknown;
+  lastUsernameChange?: unknown;
 }
 
 export interface UserDocWithId extends UserDoc {
@@ -118,7 +119,9 @@ export async function createUserDoc(uid: string, email: string, username: string
     emailVerified: false,
     totalXp: 0,
     gamesPlayed: 0,
-    createdAt: serverTimestamp()
+    createdAt: serverTimestamp(),
+    // Track when the username was last set to enforce change frequency
+    lastUsernameChange: serverTimestamp()
   };
   // Hardcoded admin gets all permissions on creation
   if (isAdmin) {
@@ -249,6 +252,11 @@ export async function updateUserProfile(uid: string, updates: UserProfileUpdates
 
   // Validate username if being changed
   if ('username' in updates) {
+    const existing = await getUserDoc(uid);
+    if (!existing) {
+      throw new Error('User not found.');
+    }
+
     const trimmed = (updates.username as string).trim();
     if (!trimmed) {
       throw new Error('Username cannot be empty.');
@@ -256,11 +264,30 @@ export async function updateUserProfile(uid: string, updates: UserProfileUpdates
     if (trimmed.length < 3) {
       throw new Error('Username must be at least 3 characters.');
     }
+
+    // Enforce one username change per 30 days
+    const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+    const lastChange = existing.lastUsernameChange as { toDate?: () => Date } | Date | undefined;
+    if (lastChange) {
+      const lastDate = typeof lastChange === 'object' && 'toDate' in lastChange
+        ? lastChange.toDate()
+        : (lastChange as Date);
+      const now = Date.now();
+      if (lastDate instanceof Date && !isNaN(lastDate.getTime())) {
+        const diff = now - lastDate.getTime();
+        if (diff < THIRTY_DAYS_MS) {
+          const daysRemaining = Math.ceil((THIRTY_DAYS_MS - diff) / (24 * 60 * 60 * 1000));
+          throw new Error(`Username can only be changed once every 30 days. Try again in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}.`);
+        }
+      }
+    }
+
     const taken = await isUsernameTaken(trimmed, uid);
     if (taken) {
       throw new Error('Username is already taken. Please choose another.');
     }
     updates.username = trimmed;
+    updates.lastUsernameChange = serverTimestamp();
   }
 
   // Validate totalXp if being changed
@@ -296,4 +323,92 @@ export async function updateUserProfile(uid: string, updates: UserProfileUpdates
   }
 
   await updateUserDoc(uid, updates as Record<string, unknown>);
+
+  // If username changed, propagate to denormalized copies in other collections
+  if ('username' in updates) {
+    const newUsername = updates.username as string;
+    await propagateUsernameChange(uid, newUsername);
+  }
+}
+
+/**
+ * Update denormalized username fields across collections so others see the change.
+ */
+async function propagateUsernameChange(uid: string, newUsername: string): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+
+  // Update lobbies: hostUsername and players[].username
+  tasks.push((async () => {
+    const lobbiesSnap = await getDocs(collection(db, 'lobbies'));
+    const updates: Promise<unknown>[] = [];
+    lobbiesSnap.forEach(docSnap => {
+      const data = docSnap.data() as { hostUid?: string; hostUsername?: string; players?: Array<{ uid: string; username: string }> };
+      let changed = false;
+      const next: typeof data.players = Array.isArray(data.players)
+        ? data.players.map(p => {
+            if (p.uid === uid && p.username !== newUsername) {
+              changed = true;
+              return { ...p, username: newUsername };
+            }
+            return p;
+          })
+        : [];
+
+      if (data.hostUid === uid && data.hostUsername !== newUsername) {
+        changed = true;
+      }
+
+      if (changed) {
+        const payload: Record<string, unknown> = { players: next };
+        if (data.hostUid === uid) {
+          payload.hostUsername = newUsername;
+        }
+        updates.push(updateDoc(doc(db, 'lobbies', docSnap.id), payload));
+      }
+    });
+    await Promise.all(updates);
+  })());
+
+  // Update friend requests: fromUsername / toUsername
+  tasks.push((async () => {
+    const requestsRef = collection(db, 'friendRequests');
+    const [fromSnap, toSnap] = await Promise.all([
+      getDocs(query(requestsRef, where('fromUid', '==', uid))),
+      getDocs(query(requestsRef, where('toUid', '==', uid)))
+    ]);
+
+    const updates: Promise<unknown>[] = [];
+    fromSnap.forEach(docSnap => {
+      const data = docSnap.data() as { fromUsername?: string };
+      if (data.fromUsername !== newUsername) {
+        updates.push(updateDoc(docSnap.ref, { fromUsername: newUsername }));
+      }
+    });
+    toSnap.forEach(docSnap => {
+      const data = docSnap.data() as { toUsername?: string };
+      if (data.toUsername !== newUsername) {
+        updates.push(updateDoc(docSnap.ref, { toUsername: newUsername }));
+      }
+    });
+
+    await Promise.all(updates);
+  })());
+
+  // Update friendships: usernames map entry
+  tasks.push((async () => {
+    const friendshipsRef = collection(db, 'friendships');
+    const friendshipsSnap = await getDocs(query(friendshipsRef, where('users', 'array-contains', uid)));
+    const updates: Promise<unknown>[] = [];
+    friendshipsSnap.forEach(docSnap => {
+      const data = docSnap.data() as { usernames?: Record<string, string> };
+      const usernames = { ...(data.usernames || {}) };
+      if (usernames[uid] !== newUsername) {
+        usernames[uid] = newUsername;
+        updates.push(updateDoc(docSnap.ref, { usernames }));
+      }
+    });
+    await Promise.all(updates);
+  })());
+
+  await Promise.all(tasks);
 }


### PR DESCRIPTION
Adds server-side validation to limit username changes to once every 30 days.

Persists `lastUsernameChange` to track change frequency and prevent abuse.

Propagates username changes across denormalized collections (lobbies, friend requests, friendships) to ensure data consistency.

Displays a client-side note about the 30-day limit.