### PR TITLE
Add Firestore backup and restore system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@
 .env.local
 .env.*.local
 
+# Firebase service-account keys (NEVER commit these)
+**/service-account-key.json
+**/serviceAccountKey.json
+
+# Firestore backup snapshots (large data files)
+backup/snapshots/
+backup/node_modules/
+
 # Dependencies
 node_modules
 

--- a/backup/firestore_backup.js
+++ b/backup/firestore_backup.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * firestore_backup.js — Export the entire Firestore database to a local JSON file.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account-key.json node firestore_backup.js [output_dir]
+ *
+ * The script recursively walks every top-level collection and all nested
+ * subcollections, serialising every document (including Timestamps, GeoPoints,
+ * and DocumentReferences) into a single JSON file.
+ *
+ * Output: <output_dir>/backup_<ISO-timestamp>.json
+ */
+
+const admin = require("firebase-admin");
+const fs = require("fs");
+const path = require("path");
+
+// ── Initialise Firebase Admin ───────────────────────────────────────────────
+admin.initializeApp({ credential: admin.credential.applicationDefault() });
+const db = admin.firestore();
+
+// ── Serialisation helpers ───────────────────────────────────────────────────
+
+/**
+ * Convert Firestore-specific types into plain JSON-safe objects so they
+ * survive a round-trip through JSON.stringify / JSON.parse.
+ */
+function serialiseValue(value) {
+  if (value === null || value === undefined) return value;
+
+  // Timestamp → { __type__: "Timestamp", seconds, nanoseconds }
+  if (value instanceof admin.firestore.Timestamp) {
+    return {
+      __type__: "Timestamp",
+      seconds: value.seconds,
+      nanoseconds: value.nanoseconds,
+    };
+  }
+
+  // GeoPoint → { __type__: "GeoPoint", latitude, longitude }
+  if (value instanceof admin.firestore.GeoPoint) {
+    return {
+      __type__: "GeoPoint",
+      latitude: value.latitude,
+      longitude: value.longitude,
+    };
+  }
+
+  // DocumentReference → { __type__: "DocumentReference", path }
+  if (value instanceof admin.firestore.DocumentReference) {
+    return { __type__: "DocumentReference", path: value.path };
+  }
+
+  // Arrays
+  if (Array.isArray(value)) {
+    return value.map(serialiseValue);
+  }
+
+  // Plain objects (maps)
+  if (typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = serialiseValue(v);
+    }
+    return out;
+  }
+
+  // Primitives (string, number, boolean)
+  return value;
+}
+
+// ── Recursive collection walker ─────────────────────────────────────────────
+
+/**
+ * Recursively export a Firestore collection (and its subcollections) into a
+ * plain JS object keyed by document ID.
+ *
+ * Returns: { docId: { __data__: { … }, __subcollections__: { collName: { … } } } }
+ */
+async function exportCollection(collectionRef) {
+  const snapshot = await collectionRef.get();
+  const result = {};
+  let docCount = 0;
+
+  for (const doc of snapshot.docs) {
+    const entry = {
+      __data__: serialiseValue(doc.data()),
+      __subcollections__: {},
+    };
+
+    // Discover subcollections on this document
+    const subcollections = await doc.ref.listCollections();
+    for (const subCol of subcollections) {
+      entry.__subcollections__[subCol.id] = await exportCollection(subCol);
+    }
+
+    // Drop the __subcollections__ key when empty to keep the file tidy
+    if (Object.keys(entry.__subcollections__).length === 0) {
+      delete entry.__subcollections__;
+    }
+
+    result[doc.id] = entry;
+    docCount++;
+  }
+
+  return result;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const outputDir = process.argv[2] || path.join(__dirname, "snapshots");
+
+  // Ensure output directory exists
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  console.log("Discovering top-level collections …");
+  const collections = await db.listCollections();
+  const collectionNames = collections.map((c) => c.id);
+  console.log(`Found ${collectionNames.length} collections: ${collectionNames.join(", ")}`);
+
+  const backup = {};
+  let totalDocs = 0;
+
+  for (const col of collections) {
+    process.stdout.write(`  Exporting "${col.id}" … `);
+    backup[col.id] = await exportCollection(col);
+    const count = Object.keys(backup[col.id]).length;
+    totalDocs += count;
+    console.log(`${count} documents`);
+  }
+
+  // Write file
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `backup_${timestamp}.json`;
+  const filepath = path.join(outputDir, filename);
+
+  fs.writeFileSync(filepath, JSON.stringify(backup, null, 2), "utf-8");
+
+  console.log("");
+  console.log(`Backup complete!`);
+  console.log(`  Total top-level documents: ${totalDocs}`);
+  console.log(`  File: ${filepath}`);
+  console.log(`  Size: ${(fs.statSync(filepath).size / 1024).toFixed(1)} KB`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Backup failed:", err);
+  process.exit(1);
+});

--- a/backup/firestore_restore.js
+++ b/backup/firestore_restore.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * firestore_restore.js — Restore a Firestore backup JSON file to the database.
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./service-account-key.json node firestore_restore.js <backup_file>
+ *
+ * WARNING: This performs a MERGE write for every document in the backup.
+ *          Documents that exist in the database but NOT in the backup file
+ *          are left untouched (no data is deleted).
+ *
+ * Supports the custom type wrappers produced by firestore_backup.js:
+ *   Timestamp, GeoPoint, DocumentReference.
+ */
+
+const admin = require("firebase-admin");
+const fs = require("fs");
+const path = require("path");
+
+// ── Initialise Firebase Admin ───────────────────────────────────────────────
+admin.initializeApp({ credential: admin.credential.applicationDefault() });
+const db = admin.firestore();
+
+// ── Deserialisation helpers ─────────────────────────────────────────────────
+
+/**
+ * Rehydrate the JSON-safe wrappers back into native Firestore types.
+ */
+function deserialiseValue(value) {
+  if (value === null || value === undefined) return value;
+
+  if (Array.isArray(value)) {
+    return value.map(deserialiseValue);
+  }
+
+  if (typeof value === "object") {
+    // Timestamp
+    if (value.__type__ === "Timestamp") {
+      return new admin.firestore.Timestamp(value.seconds, value.nanoseconds);
+    }
+    // GeoPoint
+    if (value.__type__ === "GeoPoint") {
+      return new admin.firestore.GeoPoint(value.latitude, value.longitude);
+    }
+    // DocumentReference
+    if (value.__type__ === "DocumentReference") {
+      return db.doc(value.path);
+    }
+
+    // Plain object — recurse
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = deserialiseValue(v);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+// ── Recursive importer ──────────────────────────────────────────────────────
+
+/**
+ * Restore a collection from a backup object.  Uses batched writes (max 500
+ * operations per batch) for efficiency.
+ */
+async function restoreCollection(collectionPath, collectionData) {
+  const entries = Object.entries(collectionData);
+  let written = 0;
+
+  // Firestore batches support a maximum of 500 operations each
+  const BATCH_LIMIT = 500;
+  let batch = db.batch();
+  let opsInBatch = 0;
+
+  for (const [docId, docEntry] of entries) {
+    const docRef = db.collection(collectionPath).doc(docId);
+    const data = deserialiseValue(docEntry.__data__ || docEntry);
+
+    batch.set(docRef, data, { merge: true });
+    opsInBatch++;
+    written++;
+
+    if (opsInBatch >= BATCH_LIMIT) {
+      await batch.commit();
+      batch = db.batch();
+      opsInBatch = 0;
+    }
+
+    // Recursively restore subcollections
+    if (docEntry.__subcollections__) {
+      for (const [subColName, subColData] of Object.entries(docEntry.__subcollections__)) {
+        const subColPath = `${collectionPath}/${docId}/${subColName}`;
+        await restoreCollection(subColPath, subColData);
+      }
+    }
+  }
+
+  // Commit any remaining operations
+  if (opsInBatch > 0) {
+    await batch.commit();
+  }
+
+  return written;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const backupFile = process.argv[2];
+
+  if (!backupFile) {
+    console.error("Usage: node firestore_restore.js <backup_file>");
+    console.error("");
+    console.error("  backup_file   Path to a JSON backup produced by firestore_backup.js");
+    process.exit(1);
+  }
+
+  const resolvedPath = path.resolve(backupFile);
+
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`File not found: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  console.log(`Reading backup from: ${resolvedPath}`);
+  const raw = fs.readFileSync(resolvedPath, "utf-8");
+  const backup = JSON.parse(raw);
+
+  const collectionNames = Object.keys(backup);
+  console.log(`Found ${collectionNames.length} collections: ${collectionNames.join(", ")}`);
+  console.log("");
+
+  let totalDocs = 0;
+
+  for (const collectionName of collectionNames) {
+    process.stdout.write(`  Restoring "${collectionName}" … `);
+    const count = await restoreCollection(collectionName, backup[collectionName]);
+    totalDocs += count;
+    console.log(`${count} documents`);
+  }
+
+  console.log("");
+  console.log(`Restore complete!`);
+  console.log(`  Total documents written: ${totalDocs}`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Restore failed:", err);
+  process.exit(1);
+});

--- a/backup/package.json
+++ b/backup/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hw-geogessr-firestore-backup",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Firestore backup and restore utilities for HW GeoGuessr",
+  "scripts": {
+    "backup": "node firestore_backup.js",
+    "restore": "node firestore_restore.js"
+  },
+  "dependencies": {
+    "firebase-admin": "^13.0.0"
+  }
+}

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# restore_backup.sh — Restore a local Firestore JSON snapshot back to Firebase.
+#
+# Usage:
+#   ./restore_backup.sh                         # interactive — pick from available snapshots
+#   ./restore_backup.sh backup/snapshots/backup_2025-01-15T12-00-00-000Z.json
+#
+# Prerequisites:
+#   1. Node.js installed
+#   2. A Firebase service-account key at backup/service-account-key.json
+#
+# NOTE: This performs a MERGE write — existing documents not in the backup
+#       are left untouched.  No data is deleted.
+#
+set -euo pipefail
+
+# ── Constants ────────────────────────────────────────────────────────────────
+EXPECTED_PROJECT="geogessr-a4adc"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_DIR="${SCRIPT_DIR}/backup"
+SNAPSHOTS_DIR="${BACKUP_DIR}/snapshots"
+SERVICE_ACCOUNT_KEY="${BACKUP_DIR}/service-account-key.json"
+
+# ── Colours (disabled when stdout is not a terminal) ─────────────────────────
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()   { error "$@"; exit 1; }
+
+# ── Pre-flight checks ───────────────────────────────────────────────────────
+info "Firestore restore for project '${EXPECTED_PROJECT}'"
+
+# 1. Verify Node.js is installed
+if ! command -v node &>/dev/null; then
+  die "Node.js is not installed. Install it from https://nodejs.org/"
+fi
+
+# 2. Verify we are in the correct repository
+if [ ! -f "${SCRIPT_DIR}/firebase.json" ]; then
+  die "firebase.json not found in ${SCRIPT_DIR}. Are you in the right repo?"
+fi
+
+# 3. Verify the Firebase project matches
+RC_PROJECT="$(python3 -c "import json; print(json.load(open('${SCRIPT_DIR}/.firebaserc'))['projects']['default'])" 2>/dev/null)" || true
+if [ "${RC_PROJECT}" != "${EXPECTED_PROJECT}" ]; then
+  die "Safety check failed: .firebaserc default project is '${RC_PROJECT}', expected '${EXPECTED_PROJECT}'."
+fi
+
+# 4. Verify the service-account key exists
+if [ ! -f "${SERVICE_ACCOUNT_KEY}" ]; then
+  die "Service-account key not found at ${SERVICE_ACCOUNT_KEY}.
+     Generate one from: Firebase Console → Project Settings → Service Accounts → Generate New Private Key
+     Then save it as: backup/service-account-key.json"
+fi
+
+# 5. Verify the service-account key belongs to the correct project
+SA_PROJECT="$(python3 -c "import json; print(json.load(open('${SERVICE_ACCOUNT_KEY}'))['project_id'])" 2>/dev/null)" || true
+if [ "${SA_PROJECT}" != "${EXPECTED_PROJECT}" ]; then
+  die "Service-account key belongs to project '${SA_PROJECT}', expected '${EXPECTED_PROJECT}'."
+fi
+
+info "Confirmed project: ${EXPECTED_PROJECT}"
+
+# ── Determine which backup file to restore ──────────────────────────────────
+BACKUP_FILE="${1:-}"
+
+if [ -z "${BACKUP_FILE}" ]; then
+  # No argument supplied — list available snapshots and let the user pick
+  if [ ! -d "${SNAPSHOTS_DIR}" ] || [ -z "$(ls -A "${SNAPSHOTS_DIR}" 2>/dev/null)" ]; then
+    die "No snapshots found in ${SNAPSHOTS_DIR}. Run take_backup.sh first."
+  fi
+
+  echo ""
+  info "Available snapshots:"
+  echo ""
+
+  mapfile -t SNAPSHOTS < <(ls -1t "${SNAPSHOTS_DIR}"/*.json 2>/dev/null)
+
+  if [ ${#SNAPSHOTS[@]} -eq 0 ]; then
+    die "No .json backup files found in ${SNAPSHOTS_DIR}."
+  fi
+
+  for i in "${!SNAPSHOTS[@]}"; do
+    local_file="${SNAPSHOTS[$i]}"
+    size="$(du -h "${local_file}" | cut -f1 | xargs)"
+    name="$(basename "${local_file}")"
+    echo -e "  ${CYAN}[$((i + 1))]${NC}  ${name}  (${size})"
+  done
+
+  echo ""
+  read -rp "Select a snapshot to restore (1-${#SNAPSHOTS[@]}): " choice
+
+  if ! [[ "${choice}" =~ ^[0-9]+$ ]] || [ "${choice}" -lt 1 ] || [ "${choice}" -gt "${#SNAPSHOTS[@]}" ]; then
+    die "Invalid selection: ${choice}"
+  fi
+
+  BACKUP_FILE="${SNAPSHOTS[$((choice - 1))]}"
+fi
+
+# Resolve to absolute path
+BACKUP_FILE="$(cd "$(dirname "${BACKUP_FILE}")" && pwd)/$(basename "${BACKUP_FILE}")"
+
+if [ ! -f "${BACKUP_FILE}" ]; then
+  die "Backup file not found: ${BACKUP_FILE}"
+fi
+
+info "Selected backup: $(basename "${BACKUP_FILE}")"
+
+# ── Safety confirmation ─────────────────────────────────────────────────────
+echo ""
+warn "⚠  You are about to restore data to the LIVE Firestore database for '${EXPECTED_PROJECT}'."
+warn "   This will overwrite documents that exist in both the backup and the database."
+echo ""
+read -rp "Type 'yes' to confirm: " confirm
+
+if [ "${confirm}" != "yes" ]; then
+  info "Restore cancelled."
+  exit 0
+fi
+
+# ── Install dependencies ────────────────────────────────────────────────────
+if [ ! -d "${BACKUP_DIR}/node_modules" ]; then
+  info "Installing backup dependencies …"
+  (cd "${BACKUP_DIR}" && npm install --silent)
+fi
+
+# ── Run restore ─────────────────────────────────────────────────────────────
+info "Restoring Firestore data …"
+export GOOGLE_APPLICATION_CREDENTIALS="${SERVICE_ACCOUNT_KEY}"
+node "${BACKUP_DIR}/firestore_restore.js" "${BACKUP_FILE}"
+
+echo ""
+info "Restore complete!"

--- a/take_backup.sh
+++ b/take_backup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# take_backup.sh — Export the entire Firestore database to a local JSON snapshot.
+#
+# Prerequisites:
+#   1. Node.js installed
+#   2. A Firebase service-account key at backup/service-account-key.json
+#      (generate one from the Firebase Console → Project Settings → Service Accounts)
+#
+# Output: backup/snapshots/backup_<timestamp>.json
+#
+set -euo pipefail
+
+# ── Constants ────────────────────────────────────────────────────────────────
+EXPECTED_PROJECT="geogessr-a4adc"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_DIR="${SCRIPT_DIR}/backup"
+SNAPSHOTS_DIR="${BACKUP_DIR}/snapshots"
+SERVICE_ACCOUNT_KEY="${BACKUP_DIR}/service-account-key.json"
+
+# ── Colours (disabled when stdout is not a terminal) ─────────────────────────
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+die()   { error "$@"; exit 1; }
+
+# ── Pre-flight checks ───────────────────────────────────────────────────────
+info "Starting Firestore backup for project '${EXPECTED_PROJECT}'"
+
+# 1. Verify Node.js is installed
+if ! command -v node &>/dev/null; then
+  die "Node.js is not installed. Install it from https://nodejs.org/"
+fi
+
+# 2. Verify we are in the correct repository
+if [ ! -f "${SCRIPT_DIR}/firebase.json" ]; then
+  die "firebase.json not found in ${SCRIPT_DIR}. Are you in the right repo?"
+fi
+
+# 3. Verify the Firebase project matches
+RC_PROJECT="$(python3 -c "import json; print(json.load(open('${SCRIPT_DIR}/.firebaserc'))['projects']['default'])" 2>/dev/null)" || true
+if [ "${RC_PROJECT}" != "${EXPECTED_PROJECT}" ]; then
+  die "Safety check failed: .firebaserc default project is '${RC_PROJECT}', expected '${EXPECTED_PROJECT}'."
+fi
+
+# 4. Verify the service-account key exists
+if [ ! -f "${SERVICE_ACCOUNT_KEY}" ]; then
+  die "Service-account key not found at ${SERVICE_ACCOUNT_KEY}.
+     Generate one from: Firebase Console → Project Settings → Service Accounts → Generate New Private Key
+     Then save it as: backup/service-account-key.json"
+fi
+
+# 5. Verify the service-account key belongs to the correct project
+SA_PROJECT="$(python3 -c "import json; print(json.load(open('${SERVICE_ACCOUNT_KEY}'))['project_id'])" 2>/dev/null)" || true
+if [ "${SA_PROJECT}" != "${EXPECTED_PROJECT}" ]; then
+  die "Service-account key belongs to project '${SA_PROJECT}', expected '${EXPECTED_PROJECT}'."
+fi
+
+info "Confirmed project: ${EXPECTED_PROJECT}"
+
+# ── Install dependencies ────────────────────────────────────────────────────
+if [ ! -d "${BACKUP_DIR}/node_modules" ]; then
+  info "Installing backup dependencies …"
+  (cd "${BACKUP_DIR}" && npm install --silent)
+fi
+
+# ── Run backup ──────────────────────────────────────────────────────────────
+info "Exporting Firestore data …"
+export GOOGLE_APPLICATION_CREDENTIALS="${SERVICE_ACCOUNT_KEY}"
+node "${BACKUP_DIR}/firestore_backup.js" "${SNAPSHOTS_DIR}"
+
+echo ""
+info "Backup complete! Snapshots are stored in: ${SNAPSHOTS_DIR}"


### PR DESCRIPTION
## Summary
- Add `take_backup.sh` and `restore_backup.sh` shell scripts for full Firestore database backup and restore
- Introduce `backup/` directory with Node.js scripts using Firebase Admin SDK to recursively export/import all collections, subcollections, and special Firestore types (Timestamps, GeoPoints, DocumentReferences)
- Update `.gitignore` to exclude service-account keys and snapshot data files

## Test plan
- [ ] Place a valid `service-account-key.json` in `backup/` (from Firebase Console → Project Settings → Service Accounts)
- [ ] Run `./take_backup.sh` and verify a timestamped JSON snapshot is created in `backup/snapshots/`
- [ ] Inspect the snapshot JSON to confirm all expected collections and documents are present
- [ ] Run `./restore_backup.sh` (interactive mode) and verify the snapshot selection prompt works
- [ ] Run `./restore_backup.sh backup/snapshots/<file>.json` (direct mode) and verify data is written back correctly
- [ ] Verify safety checks: wrong project rejection, missing service-account key error, confirmation prompt on restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)