### PR TITLE
Scales marker pin inversely with map zoom

### DIFF
--- a/react-vite-app/src/components/MapPicker/MapPicker.css
+++ b/react-vite-app/src/components/MapPicker/MapPicker.css
@@ -146,8 +146,10 @@ body.map-fullscreen-open {
   pointer-events: none;
   width: 26px;
   height: 26px;
-  /* Shift so the rotated pin tip (not just the layout box bottom) sits on the click point */
-  transform: translate(-50%, calc(-100% - 5.4px));
+  /* Shift so the rotated pin tip (not just the layout box bottom) sits on the click point.
+   * Scale with zoom is applied inline so the pin stays the same visual size when zoomed.
+   * Origin at pin tip (26 + 5.4 = 31.4px from top) so scaling keeps tip on the point. */
+  transform-origin: 50% 31.4px;
 }
 
 .marker-pin {
@@ -322,8 +324,8 @@ body.map-fullscreen-open {
   .marker {
     width: 22px;
     height: 22px;
-    /* 22px pin: tip offset = 11×(√2−1) ≈ 4.6px */
-    transform: translate(-50%, calc(-100% - 4.6px));
+    /* 22px pin: tip offset = 11×(√2−1) ≈ 4.6px; origin at tip = 26.6px from top */
+    transform-origin: 50% 26.6px;
   }
 
   .marker-pin {

--- a/react-vite-app/src/components/MapPicker/MapPicker.tsx
+++ b/react-vite-app/src/components/MapPicker/MapPicker.tsx
@@ -202,13 +202,15 @@ const MapPicker = forwardRef<MapPickerHandle, MapPickerProps>(function MapPicker
             </svg>
           )}
 
-          {/* Marker - positioned relative to the container which matches image size */}
+          {/* Marker - positioned relative to the container; scale inversely with zoom so pin stays same visual size */}
           {markerPosition && (
             <div
               className="marker"
               style={{
                 left: `${markerPosition.x}%`,
-                top: `${markerPosition.y}%`
+                top: `${markerPosition.y}%`,
+                transform: `translate(-50%, calc(-100% - 5.4px)) scale(${1 / scale})`,
+                transformOrigin: '50% 31.4px'
               }}
             >
               <div className="marker-pin"></div>


### PR DESCRIPTION
Ensures the map marker pin maintains a constant visual size when the map is zoomed in or out by scaling it inversely to the map's zoom level.
The transform origin is also adjusted to maintain the pin's tip position during scaling.
