### PR TITLE
Adopts server-side timestamps for duel rounds

### DIFF
--- a/react-vite-app/src/services/duelService.ts
+++ b/react-vite-app/src/services/duelService.ts
@@ -85,7 +85,7 @@ export interface DuelData {
   phase: DuelPhase;
   currentRound: number;
   currentImage: DuelImage;
-  roundStartedAt: Timestamp;
+  roundStartedAt: Timestamp | FieldValue;
   guesses: Record<string, DuelGuess>;
   health: Record<string, number>;
   roundHistory: RoundHistoryEntry[];
@@ -155,7 +155,7 @@ export async function startDuel(
       correctFloor: image.correctFloor ?? null,
       difficulty: image.difficulty || difficulty
     },
-    roundStartedAt: Timestamp.now(),
+    roundStartedAt: serverTimestamp(),
     guesses: {},
     health,
     roundHistory: [],
@@ -375,7 +375,7 @@ export async function advanceToNextRound(docId: string, difficulty: string): Pro
       correctFloor: image.correctFloor ?? null,
       difficulty: image.difficulty || difficulty
     },
-    roundStartedAt: Timestamp.now(),
+    roundStartedAt: serverTimestamp(),
     guesses: {},
     phase: 'guessing',
     updatedAt: serverTimestamp()


### PR DESCRIPTION
Ensures consistent `roundStartedAt` values by using `serverTimestamp()` when creating or advancing a duel round. This prevents discrepancies that can arise from client-side clock variations, crucial for reliable timing in a multiplayer context.

Updates the `DuelData` interface to reflect the possibility of `roundStartedAt` being a `FieldValue` before resolution to a `Timestamp`.
