### PR TITLE
Allows scrolling on photo submission page

### DIFF
--- a/react-vite-app/src/components/SubmissionApp/SubmissionApp.css
+++ b/react-vite-app/src/components/SubmissionApp/SubmissionApp.css
@@ -2,11 +2,13 @@
 
 .submission-app {
   min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   background: var(--hw-page-bg, #f2f0ec);
   color: var(--hw-black, #231f20);
   font-family: var(--hw-font-sans, 'Source Sans 3', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  overflow-y: auto;
 }
 
 /* ===== Header ===== */


### PR DESCRIPTION
Initially, the photo submission page doesn't allow users to scroll down, so the map and submit options are not fully visible.