### PR TITLE
Updated closing and forfeit conditions for multiplayer

### DIFF
--- a/react-vite-app/src/App.tsx
+++ b/react-vite-app/src/App.tsx
@@ -96,6 +96,11 @@ function App(): React.ReactElement {
   // Track whether we're in a duel (multiplayer) game
   const [inDuel, setInDuel] = useState<boolean>(false);
   const [duelLobbyDocId, setDuelLobbyDocId] = useState<string | null>(null);
+  const duelLobbyDocIdRef = useRef<string | null>(null);
+  const duelOpponentUidRef = useRef<string | null>(null);
+  const duelMyUidRef = useRef<string | null>(null);
+  const inDuelRef = useRef<boolean>(false);
+  const duelPhaseRef = useRef<string | null>(null);
 
   const {
     screen,
@@ -145,6 +150,15 @@ function App(): React.ReactElement {
     user?.uid as string,
     userDoc?.username as string
   );
+
+  // Keep duel refs current so unload handlers can forfeit immediately.
+  useEffect(() => {
+    duelLobbyDocIdRef.current = duelLobbyDocId;
+    duelOpponentUidRef.current = duel.opponentUid;
+    duelMyUidRef.current = user?.uid ?? null;
+    inDuelRef.current = inDuel;
+    duelPhaseRef.current = duel.phase;
+  }, [duelLobbyDocId, duel.opponentUid, user?.uid, inDuel, duel.phase]);
 
   // Track user's online presence and current activity
   usePresence(isGuest ? null : user as Parameters<typeof usePresence>[0], inDuel ? `duel-${duel.phase}` : screen, showSubmissionApp, showProfile, isAdmin, showLeaderboard, showFriends, showChat);
@@ -435,6 +449,86 @@ function App(): React.ReactElement {
 
     handleDuelBackToTitle();
   }, [duelLobbyDocId, duel.opponentUid, user?.uid, handleDuelBackToTitle]);
+
+  /**
+   * Best-effort unload-safe forfeit write.
+   * Uses Firestore REST commit endpoint + sendBeacon so it can complete during tab close.
+   * Works for guest and non-guest users because lobby update rules are open.
+   */
+  const sendForfeitKeepalive = useCallback((docId: string, winnerUid: string, loserUid: string): void => {
+    const projectId = import.meta.env.VITE_FIREBASE_PROJECT_ID as string | undefined;
+    const apiKey = import.meta.env.VITE_FIREBASE_API_KEY as string | undefined;
+    if (!projectId || !apiKey) return;
+
+    const encodedProject = encodeURIComponent(projectId);
+    const encodedApiKey = encodeURIComponent(apiKey);
+    const commitUrl = `https://firestore.googleapis.com/v1/projects/${encodedProject}/databases/(default)/documents:commit?key=${encodedApiKey}`;
+
+    const nowIso = new Date().toISOString();
+    const docName = `projects/${projectId}/databases/(default)/documents/lobbies/${docId}`;
+    const payload = {
+      writes: [{
+        update: {
+          name: docName,
+          fields: {
+            phase: { stringValue: 'finished' },
+            winner: { stringValue: winnerUid },
+            loser: { stringValue: loserUid },
+            forfeitBy: { stringValue: loserUid },
+            finishedAt: { timestampValue: nowIso },
+            lastActionAt: { timestampValue: nowIso },
+            updatedAt: { timestampValue: nowIso }
+          }
+        },
+        updateMask: {
+          fieldPaths: ['phase', 'winner', 'loser', 'forfeitBy', 'finishedAt', 'lastActionAt', 'updatedAt']
+        },
+        currentDocument: { exists: true }
+      }]
+    };
+
+    try {
+      const body = JSON.stringify(payload);
+      // sendBeacon is the most reliable way to transmit during unload.
+      const sent = navigator.sendBeacon(commitUrl, new Blob([body], { type: 'text/plain;charset=UTF-8' }));
+      if (sent) return;
+
+      // Fallback: keepalive fetch without custom headers to avoid unload preflight delays.
+      fetch(commitUrl, {
+        method: 'POST',
+        body,
+        keepalive: true,
+        mode: 'cors'
+      }).catch(() => { });
+    } catch {
+      // no-op: this is best-effort for unload scenarios
+    }
+  }, []);
+
+  // If a player closes/reloads the tab during an active duel, forfeit immediately.
+  useEffect(() => {
+    const handleUnloadForfeit = (): void => {
+      if (!inDuelRef.current) return;
+      if (duelPhaseRef.current === 'finished') return;
+
+      const docId = duelLobbyDocIdRef.current;
+      const opponentUid = duelOpponentUidRef.current;
+      const myUid = duelMyUidRef.current;
+
+      if (docId && opponentUid && myUid) {
+        // Fire an unload-safe REST update first, then the normal SDK path.
+        sendForfeitKeepalive(docId, opponentUid, myUid);
+        handleOpponentDisconnect(docId, opponentUid, myUid, myUid).catch(() => { });
+      }
+    };
+
+    window.addEventListener('beforeunload', handleUnloadForfeit);
+    window.addEventListener('pagehide', handleUnloadForfeit);
+    return () => {
+      window.removeEventListener('beforeunload', handleUnloadForfeit);
+      window.removeEventListener('pagehide', handleUnloadForfeit);
+    };
+  }, [sendForfeitKeepalive]);
 
   // Show loading spinner while checking auth state
   if (loading) {
@@ -856,7 +950,7 @@ function App(): React.ReactElement {
           myUid={uid}
           isHost={duel.isHost}
           onNextRound={duel.nextRound}
-          onViewFinalResults={() => {/* Will auto-transition via phase */}}
+          onViewFinalResults={() => {/* Will auto-transition via phase */ }}
           onLeaveDuel={handleDuelForfeit}
           isGameOver={false}
         />

--- a/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.css
+++ b/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.css
@@ -135,6 +135,18 @@
   font-weight: 500;
 }
 
+.duel-final-forfeit-banner {
+  margin: 0.9rem auto 0;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid rgba(200, 16, 46, 0.28);
+  background: rgba(200, 16, 46, 0.08);
+  color: var(--hw-red);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
 /* ── Score Summary Cards ── */
 .duel-final-summary {
   display: flex;

--- a/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.tsx
+++ b/react-vite-app/src/components/DuelFinalScreen/DuelFinalScreen.tsx
@@ -160,6 +160,11 @@ function DuelFinalScreen({
                 ? `You defeated ${loserUsername} in ${totalRounds} rounds!`
                 : `${winnerUsername} won after ${totalRounds} rounds`}
           </p>
+          {isWinner && forfeitBy === loser && (
+            <div className="duel-final-forfeit-banner" role="status" aria-live="polite">
+              Opponent left the duel. Win awarded by forfeit.
+            </div>
+          )}
         </div>
 
         {/* Score Summary */}

--- a/react-vite-app/src/hooks/useDuelGame.ts
+++ b/react-vite-app/src/hooks/useDuelGame.ts
@@ -161,6 +161,9 @@ export interface UseDuelGameReturn {
 const EMOTE_DISPLAY_MS = 2200;
 const EMOTE_COOLDOWN_MS = 900;
 const RANDOM_GUESS_MAX_ATTEMPTS = 200;
+const DUEL_HEARTBEAT_INTERVAL_MS = 4_000;
+const DUEL_STALE_CHECK_INTERVAL_MS = 5_000;
+const DUEL_STALE_TIMEOUT_MS = 12_000;
 
 /**
  * Custom hook for managing a duel (1v1 multiplayer) game.
@@ -254,13 +257,13 @@ export function useDuelGame(
   useEffect(() => {
     if (!lobbyDocId || !userUid) return;
 
-    sendHeartbeat(lobbyDocId, userUid).catch(() => {});
+    sendHeartbeat(lobbyDocId, userUid).catch(() => { });
 
     const heartbeatInterval = setInterval(() => {
       if (!hasLeft.current) {
-        sendHeartbeat(lobbyDocId, userUid).catch(() => {});
+        sendHeartbeat(lobbyDocId, userUid).catch(() => { });
       }
-    }, 10_000);
+    }, DUEL_HEARTBEAT_INTERVAL_MS);
 
     return () => clearInterval(heartbeatInterval);
   }, [lobbyDocId, userUid]);
@@ -271,9 +274,9 @@ export function useDuelGame(
 
     const staleCheckInterval = setInterval(() => {
       if (!hasLeft.current) {
-        removeStalePlayersFromLobby(lobbyDocId, userUid).catch(() => {});
+        removeStalePlayersFromLobby(lobbyDocId, userUid, DUEL_STALE_TIMEOUT_MS).catch(() => { });
       }
-    }, 15_000);
+    }, DUEL_STALE_CHECK_INTERVAL_MS);
 
     return () => clearInterval(staleCheckInterval);
   }, [lobbyDocId, userUid]);

--- a/react-vite-app/src/hooks/useLobby.ts
+++ b/react-vite-app/src/hooks/useLobby.ts
@@ -5,7 +5,7 @@ import {
   joinLobby,
   leaveLobby,
   subscribeLobby,
-  subscribePublicLobbyHistory,
+  subscribePublicLobbies,
   subscribeUserLobbyHistory,
   sendHeartbeat,
   removeStalePlayersFromLobby,
@@ -24,7 +24,7 @@ export interface LobbyPlayer {
   joinedAt?: string;
 }
 
-export type PublicLobby = UserLobbyHistoryDoc & {
+export type PublicLobby = LobbyDoc & {
   [key: string]: unknown;
 };
 
@@ -91,9 +91,9 @@ export function useLobby(
   const [isJoining, setIsJoining] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Subscribe to public lobby history in real-time
+  // Subscribe to active public waiting lobbies in real-time.
   useEffect(() => {
-    const unsubscribe = subscribePublicLobbyHistory((lobbies) => {
+    const unsubscribe = subscribePublicLobbies((lobbies) => {
       setPublicLobbies(lobbies as PublicLobby[]);
     });
     return unsubscribe;

--- a/react-vite-app/src/services/lobbyService.ts
+++ b/react-vite-app/src/services/lobbyService.ts
@@ -398,8 +398,15 @@ export function subscribePublicLobbies(
     where('visibility', '==', 'public'),
     where('status', '==', 'waiting')
   );
+  // Background cleanup query: include all public lobbies (including in-progress)
+  // so abandoned games can still be closed on inactivity/expiry.
+  const cleanupQuery = query(
+    collection(db, 'lobbies'),
+    where('visibility', '==', 'public')
+  );
 
   let unsubscribe = () => { };
+  let unsubscribeCleanup = () => { };
 
   const startFallback = (): void => {
     unsubscribe = onSnapshot(fallbackQuery, (snapshot) => {
@@ -423,8 +430,25 @@ export function subscribePublicLobbies(
     startFallback();
   });
 
+  unsubscribeCleanup = onSnapshot(cleanupQuery, (snapshot) => {
+    snapshot.docs.forEach((docSnap) => {
+      const lobby = { docId: docSnap.id, ...docSnap.data() } as LobbyDoc;
+      const expired = isLobbyExpired(lobby);
+      const inactive = isLobbyInactive(lobby);
+      if (expired || inactive) {
+        deleteDoc(doc(db, 'lobbies', lobby.docId)).catch((err: unknown) => {
+          console.error('Failed to delete inactive/expired public lobby (cleanup):', err);
+        });
+        markLobbyHistoryDeletedSafe(lobby.docId).catch(() => { });
+      }
+    });
+  }, (error) => {
+    console.error('Error subscribing to public lobby cleanup:', error);
+  });
+
   return () => {
     unsubscribe();
+    unsubscribeCleanup();
   };
 }
 
@@ -687,6 +711,28 @@ export async function removeStalePlayersFromLobby(
     if (!player) continue;
 
     const remaining = fresh.players.filter(p => p.uid !== stalePlayer.uid);
+
+    // Duel forfeit path:
+    // If a duel is already in progress and exactly one player remains,
+    // end the match immediately and award a forfeit win.
+    if (fresh.status === 'in_progress' && remaining.length === 1) {
+      const winnerUid = remaining[0].uid;
+      const loserUid = stalePlayer.uid;
+      const currentHealth = (fresh as unknown as { health?: Record<string, number> }).health || {};
+      const nextHealth: Record<string, number> = { ...currentHealth, [loserUid]: 0 };
+
+      await updateDoc(lobbyRef, {
+        health: nextHealth,
+        phase: 'finished',
+        winner: winnerUid,
+        loser: loserUid,
+        forfeitBy: loserUid,
+        finishedAt: serverTimestamp(),
+        lastActionAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+      });
+      return false;
+    }
 
     // If no one is left or the host has gone stale, delete the lobby (close the game).
     if (remaining.length === 0 || fresh.hostUid === stalePlayer.uid) {


### PR DESCRIPTION
Lobbies now actually close (they previously weren't closing if users just closed the tabs instead of quitting/closing the lobby). And within a game, if either the host or other user leaves the game automatically forfeits and gives the win to the remaining player.
