### PR TITLE
Removed "you are already in this lobby" prevention

### DIFF
--- a/react-vite-app/src/services/lobbyService.ts
+++ b/react-vite-app/src/services/lobbyService.ts
@@ -301,7 +301,13 @@ export async function joinLobby(
   }
 
   if (lobby.players.some(p => p.uid === playerUid)) {
-    throw new Error('You are already in this lobby.');
+    // Rejoin: user is already in lobby (e.g. host who lost tab, or reconnecting)
+    await updateDoc(lobbyRef, {
+      [`heartbeats.${playerUid}`]: Timestamp.now(),
+      lastActionAt: serverTimestamp(),
+      updatedAt: serverTimestamp()
+    });
+    return;
   }
 
   await updateDoc(lobbyRef, {


### PR DESCRIPTION
Enbales you to join game oyu are already hosting if you are in a different tab with it (say, if you lost your original tab but never quit the game).
Games will already be culled after time (if we ever fix that).
This, however, lets you rejoin in that edge case (especially since you can only host one game at a time)
