### PR TITLE
Remove testing images and button from admin panel

### DIFF
--- a/react-vite-app/package.json
+++ b/react-vite-app/package.json
@@ -14,7 +14,8 @@
     "test:ui": "vitest --ui",
     "test:watch": "vitest --watch",
     "typecheck": "tsc --noEmit",
-    "backfill:image-pool": "node scripts/backfill-image-pool.mjs"
+    "backfill:image-pool": "node scripts/backfill-image-pool.mjs",
+    "delete:testing-images": "node scripts/delete-testing-images.mjs"
   },
   "dependencies": {
     "canvas-confetti": "^1.9.4",

--- a/react-vite-app/scripts/delete-testing-images.mjs
+++ b/react-vite-app/scripts/delete-testing-images.mjs
@@ -1,0 +1,65 @@
+/**
+ * Deletes testing/sample images from Firebase.
+ * Removes documents sample-1 through sample-5 from:
+ * - images collection
+ * - imagePool collection (doc ids: image_sample-1, image_sample-2, etc.)
+ *
+ * Run with: node scripts/delete-testing-images.mjs
+ * Requires VITE_FIREBASE_* env vars to be set.
+ */
+import { initializeApp } from 'firebase/app';
+import { getFirestore, doc, getDoc, deleteDoc } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.VITE_FIREBASE_API_KEY,
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VITE_FIREBASE_APP_ID,
+  measurementId: process.env.VITE_FIREBASE_MEASUREMENT_ID
+};
+
+if (!firebaseConfig.projectId) {
+  throw new Error('Missing Firebase env vars. Export VITE_FIREBASE_* before running.');
+}
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+const SAMPLE_IDS = ['sample-1', 'sample-2', 'sample-3', 'sample-4', 'sample-5'];
+
+function poolDocId(sourceId) {
+  return `image_${sourceId}`;
+}
+
+async function run() {
+  let deletedImages = 0;
+  let deletedPool = 0;
+
+  for (const id of SAMPLE_IDS) {
+    const imageRef = doc(db, 'images', id);
+    const imageSnap = await getDoc(imageRef);
+    if (imageSnap.exists()) {
+      await deleteDoc(imageRef);
+      deletedImages += 1;
+      console.info(`Deleted images/${id}`);
+    }
+
+    const poolId = poolDocId(id);
+    const poolRef = doc(db, 'imagePool', poolId);
+    const poolSnap = await getDoc(poolRef);
+    if (poolSnap.exists()) {
+      await deleteDoc(poolRef);
+      deletedPool += 1;
+      console.info(`Deleted imagePool/${poolId}`);
+    }
+  }
+
+  console.info(`Done. Deleted ${deletedImages} from images, ${deletedPool} from imagePool.`);
+}
+
+run().catch((error) => {
+  console.error('Delete failed:', error);
+  process.exitCode = 1;
+});

--- a/react-vite-app/src/components/SubmissionApp/AdminReview.test.tsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.test.tsx
@@ -25,13 +25,11 @@ vi.mock('firebase/firestore', () => ({
 
 // Mock imageService
 const mockGetAllImages = vi.fn();
-const mockGetAllSampleImages = vi.fn();
 const mockDeleteSubmission = vi.fn();
 const mockDeleteImage = vi.fn();
 
 vi.mock('../../services/imageService', () => ({
   getAllImages: (...args: unknown[]) => mockGetAllImages(...args),
-  getAllSampleImages: (...args: unknown[]) => mockGetAllSampleImages(...args),
   deleteSubmission: (...args: unknown[]) => mockDeleteSubmission(...args),
   deleteImage: (...args: unknown[]) => mockDeleteImage(...args)
 }));
@@ -126,16 +124,6 @@ describe('AdminReview', () => {
     }
   ];
 
-  const mockSampleImages = [
-    {
-      id: 'sample-1',
-      url: 'https://example.com/sample1.jpg',
-      correctLocation: { x: 35, y: 45 },
-      correctFloor: 2,
-      description: 'Sample image 1'
-    }
-  ];
-
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -157,7 +145,6 @@ describe('AdminReview', () => {
 
     // Mock imageService - return empty by default to keep tests focused
     mockGetAllImages.mockResolvedValue([]);
-    mockGetAllSampleImages.mockReturnValue(mockSampleImages);
   });
 
   describe('loading state', () => {
@@ -193,17 +180,14 @@ describe('AdminReview', () => {
       render(<AdminReview onBack={mockOnBack} />);
       expect(screen.getByText(/Submissions/)).toBeInTheDocument();
       expect(screen.getByText(/Game Images/)).toBeInTheDocument();
-      expect(screen.getByText(/Testing Data/)).toBeInTheDocument();
     });
 
     it('should default to all filter and show all items', async () => {
       render(<AdminReview onBack={mockOnBack} />);
-      // Default filter is 'all', so all submissions + sample images should be shown
-      // Sample images are loaded async, so wait for them
+      // Default filter is 'all', so all submissions should be shown
       await waitFor(() => {
         const submissionCards = document.querySelectorAll('.submission-card');
-        // 3 submissions + 1 sample image = 4
-        expect(submissionCards.length).toBe(4);
+        expect(submissionCards.length).toBe(3);
       });
     });
   });
@@ -239,22 +223,6 @@ describe('AdminReview', () => {
       expect(submissionCards.length).toBe(1);
     });
 
-    it('should show only testing items when Testing filter is clicked', async () => {
-      const user = userEvent.setup();
-      render(<AdminReview onBack={mockOnBack} />);
-
-      // Wait for sample images to load (async useEffect)
-      await waitFor(() => {
-        expect(document.querySelectorAll('.submission-card').length).toBe(4);
-      });
-
-      // Click the "Testing (N)" status filter (not "Testing Data" source filter)
-      await user.click(screen.getByText(/^Testing \(/));
-
-      const submissionCards = document.querySelectorAll('.submission-card');
-      expect(submissionCards.length).toBe(1);
-    });
-
     it('should update active tab styling', async () => {
       const user = userEvent.setup();
       render(<AdminReview onBack={mockOnBack} />);
@@ -274,16 +242,6 @@ describe('AdminReview', () => {
 
       const submissionCards = document.querySelectorAll('.submission-card');
       expect(submissionCards.length).toBe(3);
-    });
-
-    it('should show only testing data when Testing Data source filter is clicked', async () => {
-      const user = userEvent.setup();
-      render(<AdminReview onBack={mockOnBack} />);
-
-      await user.click(screen.getByText(/^Testing Data/));
-
-      const submissionCards = document.querySelectorAll('.submission-card');
-      expect(submissionCards.length).toBe(1);
     });
 
     it('should combine source and status filters', async () => {
@@ -318,11 +276,8 @@ describe('AdminReview', () => {
     it('should display source badge', async () => {
       render(<AdminReview onBack={mockOnBack} />);
 
-      // Wait for sample images to load (async useEffect)
       await waitFor(() => {
-        // Should have Submission badges for submissions and Testing Data for samples
         expect(screen.getAllByText('Submission').length).toBe(3);
-        expect(screen.getAllByText('Testing Data').length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -493,7 +448,6 @@ describe('AdminReview', () => {
         callback({ docs: [] });
         return mockUnsubscribe;
       });
-      mockGetAllSampleImages.mockReturnValue([]);
 
       const user = userEvent.setup();
       render(<AdminReview onBack={mockOnBack} />);
@@ -714,7 +668,6 @@ describe('AdminReview', () => {
         callback({ docs: [] });
         return mockUnsubscribe;
       });
-      mockGetAllSampleImages.mockReturnValue([]);
 
       render(<AdminReview onBack={mockOnBack} />);
 
@@ -922,26 +875,6 @@ describe('AdminReview', () => {
         expect(screen.getByText('Edit')).toBeInTheDocument();
       });
 
-      it('should NOT show Edit button in modal for testing items', async () => {
-        const user = userEvent.setup();
-        // Only load testing items
-        mockOnSnapshot.mockImplementation((query: unknown, callback: (snapshot: unknown) => void) => {
-          callback({ docs: [] });
-          return vi.fn();
-        });
-
-        render(<AdminReview onBack={mockOnBack} />);
-
-        // Wait for testing data to load
-        await waitFor(() => {
-          expect(screen.getByText(/Testing Data \(1\)/)).toBeInTheDocument();
-        });
-        // Click the source filter tab for Testing Data
-        await user.click(screen.getByText(/^Testing Data \(/));
-        await user.click(screen.getByText('View Full Details'));
-
-        expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-      });
     });
 
     describe('entering and exiting edit mode', () => {
@@ -1506,24 +1439,6 @@ describe('AdminReview', () => {
         expect(screen.getByText('Delete')).toBeInTheDocument();
       });
 
-      it('should NOT show Delete button on testing data cards', async () => {
-        const user = userEvent.setup();
-        // Only show testing items
-        mockOnSnapshot.mockImplementation((query: unknown, callback: (snapshot: unknown) => void) => {
-          callback({ docs: [] });
-          return vi.fn();
-        });
-
-        render(<AdminReview onBack={mockOnBack} />);
-
-        await waitFor(() => {
-          expect(screen.getByText(/Testing Data \(1\)/)).toBeInTheDocument();
-        });
-        await user.click(screen.getByText(/^Testing Data \(/));
-
-        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
-      });
-
       it('should show Delete button in modal for submission items', async () => {
         const user = userEvent.setup();
         render(<AdminReview onBack={mockOnBack} />);
@@ -1537,24 +1452,6 @@ describe('AdminReview', () => {
         expect(modalDeleteBtn).toBeInTheDocument();
       });
 
-      it('should NOT show Delete button in modal for testing items', async () => {
-        const user = userEvent.setup();
-        mockOnSnapshot.mockImplementation((query: unknown, callback: (snapshot: unknown) => void) => {
-          callback({ docs: [] });
-          return vi.fn();
-        });
-
-        render(<AdminReview onBack={mockOnBack} />);
-
-        await waitFor(() => {
-          expect(screen.getByText(/Testing Data \(1\)/)).toBeInTheDocument();
-        });
-        await user.click(screen.getByText(/^Testing Data \(/));
-        await user.click(screen.getByText('View Full Details'));
-
-        const modalDeleteBtn = document.querySelector('.modal-header-actions .delete-photo-button');
-        expect(modalDeleteBtn).not.toBeInTheDocument();
-      });
     });
 
     describe('delete confirmation popup', () => {

--- a/react-vite-app/src/components/SubmissionApp/AdminReview.tsx
+++ b/react-vite-app/src/components/SubmissionApp/AdminReview.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom'
 import { doc, updateDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '../../firebase'
 import {
-  getAllSampleImages,
   deleteSubmission,
   deleteImage,
   getAdminSubmissionsPage,
@@ -36,8 +35,8 @@ export interface Location {
   y: number
 }
 
-type SubmissionSource = 'submission' | 'image' | 'testing'
-type SubmissionStatus = 'pending' | 'approved' | 'denied' | 'testing'
+type SubmissionSource = 'submission' | 'image'
+type SubmissionStatus = 'pending' | 'approved' | 'denied'
 
 export interface SubmissionItem {
   id: string
@@ -58,7 +57,6 @@ interface BufferedPage {
   queryKey: string
   submissions: SubmissionItem[]
   images: SubmissionItem[]
-  includeTesting: boolean
   nextSubmissionCursor: string | null
   nextImageCursor: string | null
   hasMoreSubmissions: boolean
@@ -94,11 +92,10 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
 
   const [submissions, setSubmissions] = useState<SubmissionItem[]>([])
   const [firestoreImages, setFirestoreImages] = useState<SubmissionItem[]>([])
-  const [sampleImages, setSampleImages] = useState<SubmissionItem[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [loadingMore, setLoadingMore] = useState<boolean>(false)
   const [filter, setFilter] = useState<string>('all') // pending, approved, denied, all
-  const [sourceFilter, setSourceFilter] = useState<string>('all') // all, submissions, images, testing
+  const [sourceFilter, setSourceFilter] = useState<string>('all') // all, submissions, images
   const [selectedSubmission, setSelectedSubmission] = useState<SubmissionItem | null>(null)
   const [submissionCursor, setSubmissionCursor] = useState<string | null>(null)
   const [imageCursor, setImageCursor] = useState<string | null>(null)
@@ -137,9 +134,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
   const loadedSourceCounts = useMemo(() => ({
     submission: submissions.length,
     image: firestoreImages.length,
-    testing: sampleImages.length,
-    all: submissions.length + firestoreImages.length + sampleImages.length
-  }), [firestoreImages.length, sampleImages.length, submissions.length])
+    all: submissions.length + firestoreImages.length
+  }), [firestoreImages.length, submissions.length])
 
   const BACKFILL_IMAGE_CURSOR_KEY = 'admin.imagePool.backfill.imageCursor.v1'
   const BACKFILL_SUBMISSION_CURSOR_KEY = 'admin.imagePool.backfill.submissionCursor.v1'
@@ -168,23 +164,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     } = options
     const requestId = requestSequenceRef.current
 
-    const includesSubmissions = sourceFilterValue !== 'image' && sourceFilterValue !== 'testing'
-    const includesImages = sourceFilterValue !== 'submission' && sourceFilterValue !== 'testing' && (filterValue === 'all' || filterValue === 'approved')
-    const includesTesting = sourceFilterValue === 'all' || sourceFilterValue === 'testing'
-
-    if (sourceFilterValue === 'testing') {
-      if (queryKey !== activeQueryKeyRef.current || requestId !== requestSequenceRef.current) return null
-      return {
-        queryKey,
-        submissions: [],
-        images: [],
-        includeTesting: true,
-        nextSubmissionCursor: null,
-        nextImageCursor: null,
-        hasMoreSubmissions: false,
-        hasMoreImages: false
-      }
-    }
+    const includesSubmissions = sourceFilterValue !== 'image'
+    const includesImages = sourceFilterValue !== 'submission' && (filterValue === 'all' || filterValue === 'approved')
 
     const currentSubmissionCursor = reset ? null : submissionCursorValue
     const currentImageCursor = reset ? null : imageCursorValue
@@ -250,7 +231,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
       queryKey,
       submissions: nextSubmissions,
       images: nextImages,
-      includeTesting: includesTesting,
       nextSubmissionCursor: submissionPage?.nextCursor ?? (reset ? null : submissionCursorValue),
       nextImageCursor: imagePage?.nextCursor ?? (reset ? null : imageCursorValue),
       hasMoreSubmissions: submissionPage?.hasMore ?? false,
@@ -281,16 +261,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
       const uniqueIncoming = page.images.filter((item) => !prevKeys.has(`${item._source}-${item.id}`))
       return uniqueIncoming.length === 0 ? prev : [...prev, ...uniqueIncoming]
     })
-    setSampleImages(page.includeTesting ? getAllSampleImages().map(img => ({
-      id: img.id,
-      photoURL: img.url,
-      location: img.correctLocation,
-      floor: img.correctFloor,
-      photoName: img.description || img.id,
-      status: 'testing',
-      _source: 'testing' as SubmissionSource,
-      description: img.description
-    })) : [])
     setSubmissionCursor(page.nextSubmissionCursor)
     setImageCursor(page.nextImageCursor)
     setHasMoreSubmissions(page.hasMoreSubmissions)
@@ -317,7 +287,7 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     fetchRawPage
   ])
 
-  // Fetch images from Firestore images collection and sample/testing images
+  // Fetch images from Firestore images collection
   useEffect(() => {
     activeQueryKeyRef.current = currentQueryKey
     canTriggerAutoLoadRef.current = true
@@ -332,8 +302,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     setImageCursor(null)
     setPrefetchQueue([])
     setIsPrefetching(false)
-    setHasMoreSubmissions(sourceFilter !== 'image' && sourceFilter !== 'testing')
-    setHasMoreImages(sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved'))
+    setHasMoreSubmissions(sourceFilter !== 'image')
+    setHasMoreImages(sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved'))
 
     void fetchPage({
       reset: true,
@@ -342,8 +312,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
       filterValue: filter,
       submissionCursorValue: null,
       imageCursorValue: null,
-      hasMoreSubmissionsValue: sourceFilter !== 'image' && sourceFilter !== 'testing',
-      hasMoreImagesValue: sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved')
+      hasMoreSubmissionsValue: sourceFilter !== 'image',
+      hasMoreImagesValue: sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved')
     }).catch((error) => {
       if (requestId !== requestSequenceRef.current) return
       console.error('Error fetching admin review page:', error)
@@ -409,8 +379,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
       return
     }
     const hasMoreFromState =
-      (sourceFilter !== 'image' && sourceFilter !== 'testing' && hasMoreSubmissions) ||
-      (sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved') && hasMoreImages)
+      (sourceFilter !== 'image' && hasMoreSubmissions) ||
+      (sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved') && hasMoreImages)
     if (!hasMoreFromState && prefetchQueue.length === 0) return
     setLoadingMore(true)
     try {
@@ -443,8 +413,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     const node = loadMoreRef.current
     if (!node) return
     const hasMore =
-      (sourceFilter !== 'image' && sourceFilter !== 'testing' && hasMoreSubmissions) ||
-      (sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
+      (sourceFilter !== 'image' && hasMoreSubmissions) ||
+      (sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
       prefetchQueue.length > 0
     if (!hasMore) return
 
@@ -468,8 +438,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
 
   useEffect(() => {
     const hasMoreToLoad =
-      (sourceFilter !== 'image' && sourceFilter !== 'testing' && hasMoreSubmissions) ||
-      (sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
+      (sourceFilter !== 'image' && hasMoreSubmissions) ||
+      (sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
       prefetchQueue.length > 0
     if (!hasMoreToLoad) return
     if (loading || loadingMore || isPrefetching) return
@@ -485,8 +455,8 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
 
   useEffect(() => {
     const hasMore =
-      (sourceFilter !== 'image' && sourceFilter !== 'testing' && hasMoreSubmissions) ||
-      (sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved') && hasMoreImages)
+      (sourceFilter !== 'image' && hasMoreSubmissions) ||
+      (sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved') && hasMoreImages)
     if (!hasMore || loading || loadingMore || isPrefetching || prefetchQueue.length >= PREFETCH_MAX_PAGES) return
 
     const queueTail = prefetchQueue[prefetchQueue.length - 1]
@@ -883,28 +853,22 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
   }
 
   // Combine all loaded sources; counts are fetched separately.
-  const allItems: SubmissionItem[] = useMemo(() => [...submissions, ...firestoreImages, ...sampleImages], [submissions, firestoreImages, sampleImages])
+  const allItems: SubmissionItem[] = useMemo(() => [...submissions, ...firestoreImages], [submissions, firestoreImages])
 
   const loadedStatusCounts = useMemo(() => ({
     pending: submissions.filter((item) => item.status === 'pending').length,
     approved: submissions.filter((item) => item.status === 'approved').length + firestoreImages.length,
-    denied: submissions.filter((item) => item.status === 'denied').length,
-    testing: sampleImages.length
-  }), [firestoreImages.length, sampleImages.length, submissions])
+    denied: submissions.filter((item) => item.status === 'denied').length
+  }), [firestoreImages.length, submissions])
 
   // Format count display as "loaded/total" when totals are available
-  const formatSourceCount = (source: 'all' | 'submission' | 'image' | 'testing'): string => {
+  const formatSourceCount = (source: 'all' | 'submission' | 'image'): string => {
     const loaded = loadedSourceCounts[source]
     if (!totalCounts) return `${loaded}`
 
-    if (source === 'testing') {
-      // Testing data is in-memory only, so loaded = total
-      return `${loaded}`
-    }
-
     let total: number
     if (source === 'all') {
-      total = totalCounts.submissions + totalCounts.images + sampleImages.length
+      total = totalCounts.submissions + totalCounts.images
     } else if (source === 'submission') {
       total = totalCounts.submissions
     } else {
@@ -914,13 +878,9 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     return `${loaded}/${total}`
   }
 
-  const formatStatusCount = (status: 'all' | 'pending' | 'approved' | 'denied' | 'testing'): string => {
+  const formatStatusCount = (status: 'all' | 'pending' | 'approved' | 'denied'): string => {
     if (status === 'all') {
       return formatSourceCount('all')
-    }
-
-    if (status === 'testing') {
-      return `${loadedStatusCounts.testing}`
     }
 
     const loaded = loadedStatusCounts[status]
@@ -957,7 +917,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     switch (source) {
       case 'submission': return 'source-submission'
       case 'image': return 'source-image'
-      case 'testing': return 'source-testing'
       default: return ''
     }
   }
@@ -966,7 +925,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
     switch (source) {
       case 'submission': return 'Submission'
       case 'image': return 'Game Image'
-      case 'testing': return 'Testing'
       default: return source
     }
   }
@@ -986,10 +944,10 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
 
   const roundCoordinate = (value: number): number => Math.round(value * 100) / 100
 
-  const isEditable = selectedSubmission && selectedSubmission._source !== 'testing'
+  const isEditable = Boolean(selectedSubmission)
   const hasMoreItems =
-    (sourceFilter !== 'image' && sourceFilter !== 'testing' && hasMoreSubmissions) ||
-    (sourceFilter !== 'submission' && sourceFilter !== 'testing' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
+      (sourceFilter !== 'image' && hasMoreSubmissions) ||
+      (sourceFilter !== 'submission' && (filter === 'all' || filter === 'approved') && hasMoreImages) ||
     prefetchQueue.length > 0
 
   if (loading) {
@@ -1032,12 +990,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
             >
               Game Images ({formatSourceCount('image')})
             </button>
-            <button
-              className={`filter-tab ${sourceFilter === 'testing' ? 'active' : ''}`}
-              onClick={() => setSourceFilter('testing')}
-            >
-              Testing Data ({formatSourceCount('testing')})
-            </button>
           </div>
         </div>
 
@@ -1067,12 +1019,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
               onClick={() => setFilter('denied')}
             >
               Denied ({formatStatusCount('denied')})
-            </button>
-            <button
-              className={`filter-tab ${filter === 'testing' ? 'active' : ''}`}
-              onClick={() => setFilter('testing')}
-            >
-              Testing ({formatStatusCount('testing')})
             </button>
           </div>
         </div>
@@ -1221,15 +1167,6 @@ function AdminReview({ onBack }: AdminReviewProps): React.JSX.Element {
                     Delete
                   </button>
                 </div>
-              )}
-
-              {submission._source === 'testing' && (
-                <button
-                  className="view-details-button"
-                  onClick={() => setSelectedSubmission(submission)}
-                >
-                  View Details
-                </button>
               )}
             </div>
           ))}

--- a/react-vite-app/src/services/imageService.test.ts
+++ b/react-vite-app/src/services/imageService.test.ts
@@ -13,7 +13,7 @@ vi.mock('firebase/firestore', () => ({
 }));
 
 import { collection, getDocs } from 'firebase/firestore';
-import { getRandomImage, getAllApprovedImages, getAllSampleImages } from './imageService';
+import { getRandomImage, getAllApprovedImages } from './imageService';
 
 const mockedCollection = vi.mocked(collection);
 const mockedGetDocs = vi.mocked(getDocs);
@@ -21,61 +21,6 @@ const mockedGetDocs = vi.mocked(getDocs);
 describe('imageService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('getAllSampleImages', () => {
-    it('should return an array of sample images', () => {
-      const images = getAllSampleImages();
-
-      expect(Array.isArray(images)).toBe(true);
-      expect(images.length).toBeGreaterThan(0);
-    });
-
-    it('should return at least 5 sample images', () => {
-      const images = getAllSampleImages();
-
-      expect(images.length).toBeGreaterThanOrEqual(5);
-    });
-
-    it('should return images with all required properties', () => {
-      const images = getAllSampleImages();
-
-      images.forEach((image) => {
-        expect(image).toHaveProperty('id');
-        expect(image).toHaveProperty('url');
-        expect(image).toHaveProperty('correctLocation');
-        expect(image).toHaveProperty('correctFloor');
-        expect(image).toHaveProperty('description');
-      });
-    });
-
-    it('should return a new array (not mutate original)', () => {
-      const images1 = getAllSampleImages();
-      const images2 = getAllSampleImages();
-
-      expect(images1).not.toBe(images2);
-      expect(images1).toEqual(images2);
-    });
-
-    it('should have valid location coordinates', () => {
-      const images = getAllSampleImages();
-
-      images.forEach((image: { correctLocation: { x: number; y: number } }) => {
-        expect(image.correctLocation.x).toBeGreaterThanOrEqual(0);
-        expect(image.correctLocation.x).toBeLessThanOrEqual(100);
-        expect(image.correctLocation.y).toBeGreaterThanOrEqual(0);
-        expect(image.correctLocation.y).toBeLessThanOrEqual(100);
-      });
-    });
-
-    it('should have valid floor numbers', () => {
-      const images = getAllSampleImages();
-
-      images.forEach((image: { correctFloor: number }) => {
-        expect(image.correctFloor).toBeGreaterThanOrEqual(1);
-        expect(image.correctFloor).toBeLessThanOrEqual(3);
-      });
-    });
   });
 
   describe('getAllApprovedImages', () => {

--- a/react-vite-app/src/services/imageService.ts
+++ b/react-vite-app/src/services/imageService.ts
@@ -29,15 +29,6 @@ export interface GameImage {
   description?: string | null;
 }
 
-export interface SampleImage {
-  id: string;
-  url: string;
-  correctLocation: { x: number; y: number };
-  correctFloor: number;
-  difficulty: string;
-  description: string;
-}
-
 export interface RandomImageOptions {
   excludeImageIds?: string[];
   excludeImageUrls?: string[];
@@ -151,50 +142,6 @@ function isQuotaError(error: unknown): boolean {
 }
 
 // ────── Constants ──────
-
-// Sample images for development/testing
-const SAMPLE_IMAGES: readonly SampleImage[] = [
-  {
-    id: 'sample-1',
-    url: 'https://images.unsplash.com/photo-1562774053-701939374585?w=800&q=80',
-    correctLocation: { x: 35, y: 45 },
-    correctFloor: 2,
-    difficulty: 'easy',
-    description: 'Main hallway near the library'
-  },
-  {
-    id: 'sample-2',
-    url: 'https://images.unsplash.com/photo-1541829070764-84a7d30dd3f3?w=800&q=80',
-    correctLocation: { x: 65, y: 30 },
-    correctFloor: 1,
-    difficulty: 'medium',
-    description: 'Science building entrance'
-  },
-  {
-    id: 'sample-3',
-    url: 'https://images.unsplash.com/photo-1580582932707-520aed937b7b?w=800&q=80',
-    correctLocation: { x: 80, y: 60 },
-    correctFloor: 1,
-    difficulty: 'hard',
-    description: 'Gymnasium interior'
-  },
-  {
-    id: 'sample-4',
-    url: 'https://images.unsplash.com/photo-1497633762265-9d179a990aa6?w=800&q=80',
-    correctLocation: { x: 25, y: 75 },
-    correctFloor: 3,
-    difficulty: 'easy',
-    description: 'Arts center studio'
-  },
-  {
-    id: 'sample-5',
-    url: 'https://images.unsplash.com/photo-1519452635265-7b1fbfd1e4e0?w=800&q=80',
-    correctLocation: { x: 50, y: 50 },
-    correctFloor: 2,
-    difficulty: 'medium',
-    description: 'Outdoor courtyard view'
-  }
-];
 
 const RANDOM_SELECTION_ATTEMPTS = 8;
 
@@ -622,13 +569,6 @@ export async function getAllImages(): Promise<GameImage[]> {
     console.error('Error fetching all images from Firestore:', error);
     return [];
   }
-}
-
-/**
- * Get all sample images (useful for testing)
- */
-export function getAllSampleImages(): SampleImage[] {
-  return [...SAMPLE_IMAGES];
 }
 
 /**

--- a/react-vite-app/src/test/mocks/imageService.ts
+++ b/react-vite-app/src/test/mocks/imageService.ts
@@ -37,14 +37,12 @@ export const mockImages: MockImage[] = [
 export const mockGetRandomImage = vi.fn();
 export const mockGetAllApprovedImages = vi.fn();
 export const mockGetAllImages = vi.fn();
-export const mockGetAllSampleImages = vi.fn();
 
 // Setup default implementations
 export const setupImageServiceMocks = (): void => {
   mockGetRandomImage.mockResolvedValue(mockImages[0]);
   mockGetAllApprovedImages.mockResolvedValue([...mockImages]);
   mockGetAllImages.mockResolvedValue([...mockImages]);
-  mockGetAllSampleImages.mockReturnValue([...mockImages]);
 };
 
 // Reset mocks helper
@@ -52,7 +50,6 @@ export const resetImageServiceMocks = (): void => {
   mockGetRandomImage.mockReset();
   mockGetAllApprovedImages.mockReset();
   mockGetAllImages.mockReset();
-  mockGetAllSampleImages.mockReset();
   setupImageServiceMocks();
 };
 

--- a/react-vite-app/src/test/typecheck.test.ts
+++ b/react-vite-app/src/test/typecheck.test.ts
@@ -35,7 +35,7 @@ import type {
   UserLookup, FriendRequestStatus, FriendRequestDirection,
   FriendRequestDoc, FriendDoc, FriendshipDoc,
 } from '../services/friendService';
-import type { GameImage, SampleImage } from '../services/imageService';
+import type { GameImage } from '../services/imageService';
 import type { LevelInfo as LeaderboardLevelInfo, LeaderboardEntry } from '../services/leaderboardService';
 import type {
   LobbyStatus, LobbyVisibility, LobbyPlayer as ServiceLobbyPlayer,


### PR DESCRIPTION
- Remove Testing Data source filter tab and Testing status filter from AdminReview
- Remove SAMPLE_IMAGES constant and getAllSampleImages from imageService
- Add delete-testing-images.mjs script to remove sample-1 through sample-5 from
  Firebase images and imagePool collections
- Update AdminReview and imageService tests to remove testing-related assertions
- Remove SampleImage type and mockGetAllSampleImages from test mocks
